### PR TITLE
Feat(EditRegistry)

### DIFF
--- a/ClientApp/package.json
+++ b/ClientApp/package.json
@@ -23,10 +23,12 @@
     "@angular/platform-browser-dynamic": "^5.2.0",
     "@angular/platform-server": "^5.2.0",
     "@angular/router": "^5.2.0",
+    "@ng-bootstrap/ng-bootstrap": "^1.1.2",
     "@nguniversal/module-map-ngfactory-loader": "^5.0.0-beta.5",
     "aspnet-prerendering": "^3.0.1",
     "bootstrap": "^3.3.7",
     "core-js": "^2.4.1",
+    "ngx-bootstrap": "2.0.4",
     "rxjs": "^5.5.6",
     "zone.js": "^0.8.19"
   },

--- a/ClientApp/src/app/app.module.ts
+++ b/ClientApp/src/app/app.module.ts
@@ -16,6 +16,7 @@ import { IndicatorGroupService } from './services/indicator-group/indicator-grou
 
 import { NgbModule } from '@ng-bootstrap/ng-bootstrap';
 import { RegistryEditorComponent } from './components/indicator-detail/registry-editor/registry-editor.component';
+import { RegistryService } from './services/registry/registry.service';
 
 @NgModule({
   declarations: [
@@ -39,7 +40,7 @@ import { RegistryEditorComponent } from './components/indicator-detail/registry-
       { path: '**',          component: IndicatorHomeComponent }
     ])
   ],
-  providers: [IndicatorService, IndicatorGroupService],
+  providers: [IndicatorService, IndicatorGroupService, RegistryService],
   bootstrap: [AppComponent]
 })
 export class AppModule { }

--- a/ClientApp/src/app/app.module.ts
+++ b/ClientApp/src/app/app.module.ts
@@ -14,6 +14,9 @@ import { IndicatorDetailComponent } from './components/indicator-detail/indicato
 import { IndicatorService } from './services/indicator/indicator.service';
 import { IndicatorGroupService } from './services/indicator-group/indicator-group.service';
 
+import { NgbModule } from '@ng-bootstrap/ng-bootstrap';
+import { RegistryEditorComponent } from './components/indicator-detail/registry-editor/registry-editor.component';
+
 @NgModule({
   declarations: [
     AppComponent,
@@ -21,13 +24,14 @@ import { IndicatorGroupService } from './services/indicator-group/indicator-grou
     FooterComponent,
     IndicatorHomeComponent,
     IndicatorDetailComponent,
-    IndicatorDisplayComponent
+    IndicatorDisplayComponent,
+    RegistryEditorComponent
   ],
   imports: [
     BrowserModule.withServerTransition({ appId: 'ng-cli-universal' }),
     HttpClientModule,
     FormsModule,
-
+    NgbModule.forRoot(),
     RouterModule.forRoot([
       { path: 'indicator/:idIndicator', component: IndicatorDetailComponent },
       { path: 'home',        component: IndicatorHomeComponent },

--- a/ClientApp/src/app/app.module.ts
+++ b/ClientApp/src/app/app.module.ts
@@ -3,6 +3,7 @@ import { NgModule } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { HttpClientModule } from '@angular/common/http';
 import { RouterModule } from '@angular/router';
+import { ModalModule } from 'ngx-bootstrap/modal';
 
 import { AppComponent } from './app.component';
 import { HeaderComponent } from './components/header/header.component';
@@ -14,7 +15,6 @@ import { IndicatorDetailComponent } from './components/indicator-detail/indicato
 import { IndicatorService } from './services/indicator/indicator.service';
 import { IndicatorGroupService } from './services/indicator-group/indicator-group.service';
 
-import { NgbModule } from '@ng-bootstrap/ng-bootstrap';
 import { RegistryEditorComponent } from './components/indicator-detail/registry-editor/registry-editor.component';
 import { RegistryService } from './services/registry/registry.service';
 
@@ -32,7 +32,7 @@ import { RegistryService } from './services/registry/registry.service';
     BrowserModule.withServerTransition({ appId: 'ng-cli-universal' }),
     HttpClientModule,
     FormsModule,
-    NgbModule.forRoot(),
+    ModalModule.forRoot(),
     RouterModule.forRoot([
       { path: 'indicator/:idIndicator', component: IndicatorDetailComponent },
       { path: 'home',        component: IndicatorHomeComponent },

--- a/ClientApp/src/app/components/indicator-detail/indicator-detail.component.html
+++ b/ClientApp/src/app/components/indicator-detail/indicator-detail.component.html
@@ -3,27 +3,39 @@
 <br>
 <br>
 <br>
-<div class="container">
-  <h1>    {{ indicator.name }}</h1>
-<!--h2>Tipo: {{ indicator.type }}</h2-->
-<div *ngIf="indicator.type == -1">El tipo es default...</div>
 
 <ng-template #loading>
-  Cargando...
+  <div class="container">
+    <h2>Cargando datos...</h2>
+  </div>
+</ng-template>
+
+<ng-template #noRegistries>
+    <h2>Aún no se han añadido registros.</h2>
 </ng-template>
 
 
-<div class="heading-block">
-  <h2>Detalle de Registros</h2>
-</div>
+
+<div class="container">
+  <h1>    {{ indicator.name }}</h1>
+  <!--h2>Tipo: {{ indicator.type }}</h2-->
+  <!--<div *ngIf="indicator.type == -1">El tipo es default...</div>-->
+
+  <app-registry-editor></app-registry-editor>
+
+
+  <div class="heading-block" *ngIf="registriesCount != 0; else noRegistries">
+    <h2>Detalle de Registros</h2>
+  </div>
 
   <div class="panel panel-default" *ngFor="let registry of indicator.registries">
+
     <!-- Default panel contents -->
     <div class="panel-heading">
       {{registry.name}}
       <div class="pull-right">
         <button href="#" class="btn btn-success btn-xs"> <span class="glyphicon glyphicon-pencil">  </span>  </button>
-        <button href="#" class="btn btn-danger btn-xs" (click)="deleteRegistry(registry)" > <span class="glyphicon glyphicon-trash"> </span> </button>
+        <button href="#" class="btn btn-danger btn-xs" (click)="deleteRegistry(registry)"> <span class="glyphicon glyphicon-trash"> </span> </button>
       </div>
     </div>
     <div class="panel-body">
@@ -37,8 +49,10 @@
     </div>
   </div>
 
-<button type="button" class="btn btn-primary btn-lg" data-toggle="modal" data-target="#modal-login">
-  Añadir registro
-</button>
+
+
+  <button type="button" class="btn btn-primary btn-lg" data-toggle="modal" data-target="#modal-login">
+    Añadir registro
+  </button>
 
 </div>

--- a/ClientApp/src/app/components/indicator-detail/indicator-detail.component.html
+++ b/ClientApp/src/app/components/indicator-detail/indicator-detail.component.html
@@ -11,7 +11,7 @@
 </ng-template>
 
 <ng-template #noRegistries>
-    <h2>Aún no se han añadido registros.</h2>
+    <h2>Aún no se han cargado registros.</h2>
 </ng-template>
 
 
@@ -20,7 +20,7 @@
   <h1>    {{ indicator.name }}</h1>
   <!--h2>Tipo: {{ indicator.type }}</h2-->
   <!--<div *ngIf="indicator.type == -1">El tipo es default...</div>-->
-  <app-registry-editor [registry]="registry"></app-registry-editor>
+  
 
   <div class="heading-block" *ngIf="registriesCount != 0; else noRegistries">
     <h2>Detalle de Registros</h2>
@@ -31,7 +31,7 @@
     <div class="panel-heading">
       {{registry.name}}
       <div class="pull-right">
-        <button href="#" class="btn btn-success btn-xs" (click)="editRegistry(registry)"> <span class="glyphicon glyphicon-pencil">  </span>  </button>
+        <button href="#" class="btn btn-success btn-xs" (click)="openModalEditRegistry(editRegistry,registry)"> <span class="glyphicon glyphicon-pencil">  </span>  </button>
         <button href="#" class="btn btn-danger btn-xs" (click)="deleteRegistry(registry)"> <span class="glyphicon glyphicon-trash"> </span> </button>
       </div>
     </div>
@@ -52,4 +52,20 @@
     Añadir registro
   </button>
 
+
+  <!--Modal Edit Registry-->
+  
+  <ng-template #editRegistry>
+    <div class="modal-header">
+      <h4 class="modal-title pull-left">Editar registro</h4>
+      <button type="button" class="close pull-right" aria-label="close" (click)="editModalRef.hide()">
+        <span aria-hidden="true">&times;</span>
+      </button>
+    </div>
+    <div class="modal-body">
+      <app-registry-editor [registry]="registry" [editModalRef]="editModalRef"></app-registry-editor>
+    </div>
+  </ng-template>
+
+  <!--END Modal Edit Registry-->
 </div>

--- a/ClientApp/src/app/components/indicator-detail/indicator-detail.component.html
+++ b/ClientApp/src/app/components/indicator-detail/indicator-detail.component.html
@@ -20,21 +20,18 @@
   <h1>    {{ indicator.name }}</h1>
   <!--h2>Tipo: {{ indicator.type }}</h2-->
   <!--<div *ngIf="indicator.type == -1">El tipo es default...</div>-->
-
-  <app-registry-editor></app-registry-editor>
-
+  <app-registry-editor [registry]="registry"></app-registry-editor>
 
   <div class="heading-block" *ngIf="registriesCount != 0; else noRegistries">
     <h2>Detalle de Registros</h2>
   </div>
 
   <div class="panel panel-default" *ngFor="let registry of indicator.registries">
-
     <!-- Default panel contents -->
     <div class="panel-heading">
       {{registry.name}}
       <div class="pull-right">
-        <button href="#" class="btn btn-success btn-xs"> <span class="glyphicon glyphicon-pencil">  </span>  </button>
+        <button href="#" class="btn btn-success btn-xs" (click)="editRegistry(registry)"> <span class="glyphicon glyphicon-pencil">  </span>  </button>
         <button href="#" class="btn btn-danger btn-xs" (click)="deleteRegistry(registry)"> <span class="glyphicon glyphicon-trash"> </span> </button>
       </div>
     </div>
@@ -43,7 +40,7 @@
       <table class="table">
         <tr><td><b>Fecha</b></td><td>{{registry.date | date:'dd-MM-yyyy'}}</td></tr>
         <tr *ngIf="indicator.type == 1"><td><b>Cantidad</b></td><td>{{registry.quantity}}</td></tr>
-        <tr *ngIf="indicator.type == 2"><td><b>Porcentaje</b></td><td>{{registry.percent | percent}}</td></tr>
+        <tr *ngIf="indicator.type == 2"><td><b>Porcentaje</b></td><td>{{registry.percent}}%</td></tr>
         <tr><td><b>Documento respaldo</b></td><td><a href="{{ registry.urlDocument }}">Descargar respaldo</a></td></tr>
       </table>
     </div>

--- a/ClientApp/src/app/components/indicator-detail/indicator-detail.component.html
+++ b/ClientApp/src/app/components/indicator-detail/indicator-detail.component.html
@@ -36,13 +36,42 @@
       </div>
     </div>
     <div class="panel-body">
+        <div class="container">
+            <h6>Datos registro</h6>
+        </div>
       <!-- Table -->
       <table class="table">
-        <tr><td><b>Fecha</b></td><td>{{registry.date | date:'dd-MM-yyyy'}}</td></tr>
+        <tr><td><b>Fecha ingreso de registro</b></td><td></td><td></td><td>{{registry.date | date:'dd-MM-yyyy'}}</td></tr>
         <tr *ngIf="indicator.type == 1"><td><b>Cantidad</b></td><td>{{registry.quantity}}</td></tr>
         <tr *ngIf="indicator.type == 2"><td><b>Porcentaje</b></td><td>{{registry.percent}}%</td></tr>
-        <tr><td><b>Documento respaldo</b></td><td><a href="{{ registry.urlDocument }}">Descargar respaldo</a></td></tr>
       </table>
+      <div class="container">
+          <h6>Documentos de respaldo</h6>
+      </div>
+      <table class="table">
+        <tr *ngFor = "let document of registry.documents">
+          <td><b>{{document.name}}</b></td>
+          <td>{{document.date | date: 'dd-MM-yyyy'}}</td>
+          <td><a href="{{ document.link }}">Descargar</a></td>
+          <td><button class="btn btn-danger btn-xs pull-right" (click)="deleteDocument(registry,document)" > <span class="glyphicon glyphicon-trash"> </span> </button></td>
+        </tr>
+      </table>
+      <!--
+      <table class="table">
+        <thead>
+            <tr><td><b>Documentos de respaldo</b></td><td></td><td></td></tr>
+        <p *ngIf="registry.documents.length == 0"><em> No hay documentos</em></p>
+            
+        </thead>
+        <tbody>
+            <tr *ngFor = "let document of registry.documents">
+                <td><b>{{document.name}}</b></td>
+                <td><a href={{document.link}}>Descargar</a></td>
+                <td><button href="#" class="btn btn-danger btn-xs pull-right" (click)="deleteDocument(document)" > <span class="glyphicon glyphicon-trash"> </span> </button></td>
+              </tr>
+        </tbody>
+      </table>
+      -->
     </div>
   </div>
 
@@ -54,17 +83,8 @@
 
 
   <!--Modal Edit Registry-->
-  
   <ng-template #editRegistry>
-    <div class="modal-header">
-      <h4 class="modal-title pull-left">Editar registro</h4>
-      <button type="button" class="close pull-right" aria-label="close" (click)="editModalRef.hide()">
-        <span aria-hidden="true">&times;</span>
-      </button>
-    </div>
-    <div class="modal-body">
-      <app-registry-editor [registry]="registry" [editModalRef]="editModalRef"></app-registry-editor>
-    </div>
+      <app-registry-editor [registry]="registry" [type]="type" [editModalRef]="editModalRef" #editRegistry></app-registry-editor>
   </ng-template>
 
   <!--END Modal Edit Registry-->

--- a/ClientApp/src/app/components/indicator-detail/indicator-detail.component.ts
+++ b/ClientApp/src/app/components/indicator-detail/indicator-detail.component.ts
@@ -21,6 +21,8 @@ export class IndicatorDetailComponent implements OnInit {
   public idIndicator = -1;
   public registriesCount = 0;
 
+  public registry: {registry: Registry, type: number};
+
   constructor(private service: IndicatorService,
     private route: ActivatedRoute) {
     this.idIndicator = this.route.snapshot.params.idIndicator;
@@ -37,6 +39,10 @@ export class IndicatorDetailComponent implements OnInit {
       this.registriesCount = data.registries.length},
       err => console.error(err)
       );
+  }
+
+  private editRegistry(registry: Registry) {
+    this.registry = { registry: registry, type: this.indicator.type };
   }
 
   private deleteRegistry (registry: Registry) {

--- a/ClientApp/src/app/components/indicator-detail/indicator-detail.component.ts
+++ b/ClientApp/src/app/components/indicator-detail/indicator-detail.component.ts
@@ -4,6 +4,7 @@ import { PercentPipe } from '@angular/common';
 import { Indicator } from '../../shared/models/indicator';
 import { IndicatorType } from '../../shared/models/indicatorType';
 import { Registry } from '../../shared/models/registry';
+import { Document } from '../../shared/models/document';
 
 import { BsModalService } from 'ngx-bootstrap/modal';
 import { BsModalRef } from 'ngx-bootstrap/modal/bs-modal-ref.service';
@@ -13,6 +14,7 @@ import { IndicatorService } from '../../services/indicator/indicator.service';
 import { Observable } from 'rxjs/Observable';
 import { Http, Response, Headers, RequestOptions,  } from '@angular/http';
 import { HttpClient } from '@angular/common/http';
+import { RegistryService } from '../../services/registry/registry.service';
 
 @Component({
   selector: 'app-indicator-detail',
@@ -24,10 +26,12 @@ export class IndicatorDetailComponent implements OnInit {
   public idIndicator = -1;
   public registriesCount = 0;
 
-  public registry: {registry: Registry, type: number};
+  public registry: Registry = null; // For EditRegistry
+  public type: number;
   public editModalRef: BsModalRef;
 
   constructor(private service: IndicatorService,
+    private registryService: RegistryService,
     private route: ActivatedRoute,
     private modalService: BsModalService) {
     this.idIndicator = this.route.snapshot.params.idIndicator;
@@ -37,17 +41,17 @@ export class IndicatorDetailComponent implements OnInit {
     this.getIndicator(this.idIndicator);
   }
 
-  openModalEditRegistry(template: TemplateRef<any>, registry: Registry) {
-    this.registry = { registry: registry, type: this.indicator.type };
+  openModalEditRegistry(template: TemplateRef<any>, selectedRegistry: Registry) {
+    this.registry = selectedRegistry;
+    this.type = this.indicator.type;
     this.editModalRef = this.modalService.show(template);
-    
   }
-  
+
   private getIndicator(indicatorId: number) {
     this.service.getIndicator(indicatorId).subscribe(
       data => {
       this.indicator = data;
-      this.registriesCount = data.registries.length},
+      this.registriesCount = data.registries.length; },
       err => console.error(err)
       );
   }
@@ -74,7 +78,28 @@ export class IndicatorDetailComponent implements OnInit {
       if ( index !== -1) {
         this.indicator.registries.splice(index, 1);
       }
-      console.log(this.indicator.registries);
+    }
+  }
+
+  deleteDocument(registry: Registry, document: Document) {
+    const result = confirm('Está seguro que desea elimianr el documento: ' + document.documentName);
+    if (registry.documents.length === 1) {
+      alert('Debe existir al menos un documento de respaldo para el registro');
+      return;
+    }
+    if (result) {
+      let removed: Document;
+      this.registryService.deleteDocument(document).subscribe(
+        data => {
+          removed = data;
+        },
+        err => console.error(err)
+      );
+
+      const index: number = registry.documents.indexOf(document);
+      if (index !== -1) {
+        registry.documents.splice(index, 1);
+      }
     }
   }
 

--- a/ClientApp/src/app/components/indicator-detail/indicator-detail.component.ts
+++ b/ClientApp/src/app/components/indicator-detail/indicator-detail.component.ts
@@ -1,12 +1,15 @@
 import { ActivatedRoute } from '@angular/router';
-import { Component, OnInit, Inject } from '@angular/core';
+import { Component, OnInit, Inject, TemplateRef } from '@angular/core';
 import { PercentPipe } from '@angular/common';
 import { Indicator } from '../../shared/models/indicator';
 import { IndicatorType } from '../../shared/models/indicatorType';
+import { Registry } from '../../shared/models/registry';
+
+import { BsModalService } from 'ngx-bootstrap/modal';
+import { BsModalRef } from 'ngx-bootstrap/modal/bs-modal-ref.service';
 
 // Services
 import { IndicatorService } from '../../services/indicator/indicator.service';
-import { Registry } from '../../shared/models/registry';
 import { Observable } from 'rxjs/Observable';
 import { Http, Response, Headers, RequestOptions,  } from '@angular/http';
 import { HttpClient } from '@angular/common/http';
@@ -22,14 +25,22 @@ export class IndicatorDetailComponent implements OnInit {
   public registriesCount = 0;
 
   public registry: {registry: Registry, type: number};
+  public editModalRef: BsModalRef;
 
   constructor(private service: IndicatorService,
-    private route: ActivatedRoute) {
+    private route: ActivatedRoute,
+    private modalService: BsModalService) {
     this.idIndicator = this.route.snapshot.params.idIndicator;
   }
 
   ngOnInit() {
     this.getIndicator(this.idIndicator);
+  }
+
+  openModalEditRegistry(template: TemplateRef<any>, registry: Registry) {
+    this.registry = { registry: registry, type: this.indicator.type };
+    this.editModalRef = this.modalService.show(template);
+    
   }
   
   private getIndicator(indicatorId: number) {
@@ -41,9 +52,9 @@ export class IndicatorDetailComponent implements OnInit {
       );
   }
 
-  private editRegistry(registry: Registry) {
+  /*private editRegistry(registry: Registry) {
     this.registry = { registry: registry, type: this.indicator.type };
-  }
+  }*/
 
   private deleteRegistry (registry: Registry) {
     const date: Date = new Date(registry.date);

--- a/ClientApp/src/app/components/indicator-detail/indicator-detail.component.ts
+++ b/ClientApp/src/app/components/indicator-detail/indicator-detail.component.ts
@@ -19,18 +19,22 @@ import { HttpClient } from '@angular/common/http';
 export class IndicatorDetailComponent implements OnInit {
   public indicator: Indicator = new Indicator();
   public idIndicator = -1;
+  public registriesCount = 0;
 
   constructor(private service: IndicatorService,
-              private route: ActivatedRoute) {
+    private route: ActivatedRoute) {
     this.idIndicator = this.route.snapshot.params.idIndicator;
   }
 
   ngOnInit() {
     this.getIndicator(this.idIndicator);
   }
+  
   private getIndicator(indicatorId: number) {
     this.service.getIndicator(indicatorId).subscribe(
-      data => { this.indicator = data; },
+      data => {
+      this.indicator = data;
+      this.registriesCount = data.registries.length},
       err => console.error(err)
       );
   }
@@ -43,7 +47,9 @@ export class IndicatorDetailComponent implements OnInit {
     if (result) {
       let removed: Registry;
       this.service.deleteRegistry(registry.registryID).subscribe(
-        data => {removed = data; },
+        data => {
+          removed = data;
+          this.registriesCount--;},
         err => console.error(err)
       );
 

--- a/ClientApp/src/app/components/indicator-detail/registry-editor/registry-editor.component.css
+++ b/ClientApp/src/app/components/indicator-detail/registry-editor/registry-editor.component.css
@@ -1,0 +1,7 @@
+.ng-valid[required], .ng-valid.required {
+  border-left: 5px solid #5cb85c; /* green */
+}
+
+.ng-invalid:not(form) {
+  border-left: 5px solid #d9534f; /* red */
+}

--- a/ClientApp/src/app/components/indicator-detail/registry-editor/registry-editor.component.html
+++ b/ClientApp/src/app/components/indicator-detail/registry-editor/registry-editor.component.html
@@ -1,0 +1,20 @@
+<ng-template #content let-c="close" let-d="dismiss">
+  <div class="modal-header">
+    <h4 class="modal-title">Modal title</h4>
+    <button type="button" class="close" aria-label="Close" (click)="d('Cross click')">
+      <span aria-hidden="true">&times;</span>
+    </button>
+  </div>
+  <div class="modal-body">
+    <p>One fine body&hellip;</p>
+  </div>
+  <div class="modal-footer">
+    <button type="button" class="btn btn-outline-dark" (click)="c('Close click')">Close</button>
+  </div>
+</ng-template>
+
+<button class="btn btn-lg btn-outline-primary" (click)="open(content)">Launch demo modal</button>
+
+<hr>
+
+<pre>{{closeResult}}</pre>

--- a/ClientApp/src/app/components/indicator-detail/registry-editor/registry-editor.component.html
+++ b/ClientApp/src/app/components/indicator-detail/registry-editor/registry-editor.component.html
@@ -1,20 +1,50 @@
-<ng-template #content let-c="close" let-d="dismiss">
-  <div class="modal-header">
-    <h4 class="modal-title">Modal title</h4>
-    <button type="button" class="close" aria-label="Close" (click)="d('Cross click')">
-      <span aria-hidden="true">&times;</span>
-    </button>
-  </div>
-  <div class="modal-body">
-    <p>One fine body&hellip;</p>
-  </div>
-  <div class="modal-footer">
-    <button type="button" class="btn btn-outline-dark" (click)="c('Close click')">Close</button>
-  </div>
+<div class="container" *ngIf="registry; else noRegistry;">
+  <h2>Editar Registro</h2>
+  <form (ngSubmit)="editRegistry()" #registryEditForm="ngForm">
+    <div class="form-group">
+      <label for="name">Nombre</label>
+      <input type="text" class="form-control" id="name" required [(ngModel)]="registry.registry.name" name="name" #name="ngModel" />
+      <div [hidden]="name.valid || name.pristine"
+           class="alert alert-danger">
+        Nombre no puede estar vacio
+      </div>
+    </div>
+
+    <div class="form-group">
+      <label for="date">Fecha</label>
+      <input type="date" class="form-control" id="date" required [(ngModel)]="registry.registry.date" name="date" #date="ngModel" />
+      <div [hidden]="(date.valid || date.pristine)"
+           class="alert alert-danger">
+        Fecha es requerida
+      </div>
+    </div>
+
+    <div class="form-group" *ngIf="registry.type === 1">
+      <label for="quantity">Valor</label>
+      <input type="text" pattern="[0-9]{1,}" class="form-control" id="quantity" required [(ngModel)]="registry.registry.quantity" name="quantity" #quantity="ngModel" />
+      <div [hidden]="(quantity.valid || quantity.pristine)"
+           class="alert alert-danger">
+        Cantidad deber ser un número entero
+      </div>
+    </div>
+
+    <div class="form-group" *ngIf="registry.type === 2">
+      <label for="percent">Porcentaje</label>
+      <input type="text" pattern="[0-9]{1,}[\.]{0,1}[0-9]{1,}" class="form-control" id="percent" required [(ngModel)]="registry.registry.percent" name="percent" #percent="ngModel" />
+      <div [hidden]="(percent.valid || percent.pristine)"
+           class="alert alert-danger">
+        Porcentaje debe ser un número entero o decimal (punto "." es separador de decimales)
+      </div>
+    </div>
+    <button type="submit" class="btn btn-success pull-right" [disabled]="!registryEditForm.form.valid">Editar</button>
+
+  </form>
+</div>
+
+{{registry.registry | json}}
+
+<ng-template #noRegistry>
+  <em>
+    Registro no seleccionado.
+  </em>
 </ng-template>
-
-<button class="btn btn-lg btn-outline-primary" (click)="open(content)">Launch demo modal</button>
-
-<hr>
-
-<pre>{{closeResult}}</pre>

--- a/ClientApp/src/app/components/indicator-detail/registry-editor/registry-editor.component.html
+++ b/ClientApp/src/app/components/indicator-detail/registry-editor/registry-editor.component.html
@@ -1,60 +1,70 @@
-<form (ngSubmit)="editRegistry()" #registryEditForm="ngForm">
-  <div class="form-group">
-    <label for="name">Nombre</label>
-    <input type="text" class="form-control" id="name" required [(ngModel)]="registry.registry.name" name="name" #name="ngModel" />
-    <div [hidden]="name.valid || name.pristine"
-          class="alert alert-danger">
-      Nombre no puede estar vacio
+
+<div class="modal-header">
+  <h4 class="modal-title pull-left">Editar registro</h4>
+  <button type="button" class="close pull-right" aria-label="close" (click)="editModalRef.hide()">
+    <span aria-hidden="true">&times;</span>
+  </button>
+</div>
+<div class="modal-body">
+  <form (ngSubmit)="editRegistry()" #registryEditForm="ngForm">
+    <div class="form-group">
+      <label for="name">Nombre</label>
+      <input type="text" class="form-control" id="name" required [(ngModel)]="registry.name" name="name" #name="ngModel" />
+      <div [hidden]="name.valid || name.pristine"
+            class="alert alert-danger">
+        Nombre no puede estar vacio
+      </div>
     </div>
-  </div>
 
-  <div class="form-group">
-    <label for="date">Fecha</label>
-    <input type="date" class="form-control" id="date" required [(ngModel)]="registry.registry.date" name="date" #date="ngModel" />
-    <div [hidden]="(date.valid || date.pristine)"
-          class="alert alert-danger">
-      Fecha es requerida
+    <div class="form-group">
+      <label for="date">Fecha</label>
+      <input type="date" class="form-control" id="date" required [(ngModel)]="registry.date" name="date" #date="ngModel" />
+      <div [hidden]="(date.valid || date.pristine)"
+            class="alert alert-danger">
+        Fecha es requerida
+      </div>
     </div>
-  </div>
 
-  <div class="form-group" *ngIf="registry.type === 1">
-    <label for="quantity">Valor</label>
-    <input type="text" pattern="[0-9]{1,}" class="form-control" id="quantity" required [(ngModel)]="registry.registry.quantity" name="quantity" #quantity="ngModel" />
-    <div [hidden]="(quantity.valid || quantity.pristine)"
-          class="alert alert-danger">
-      Cantidad deber ser un número entero
+    <div class="form-group" *ngIf="registry.type === 1">
+      <label for="quantity">Valor</label>
+      <input type="text" pattern="[0-9]{1,}" class="form-control" id="quantity" required [(ngModel)]="registry.quantity" name="quantity" #quantity="ngModel" />
+      <div [hidden]="(quantity.valid || quantity.pristine)"
+            class="alert alert-danger">
+        Cantidad deber ser un número entero
+      </div>
     </div>
-  </div>
 
-  <div class="form-group" *ngIf="registry.type === 2">
-    <label for="percent">Porcentaje</label>
-    <input type="text" pattern="[0-9]{1,}[\.]{0,1}[0-9]{1,}" class="form-control" id="percent" required [(ngModel)]="registry.registry.percent" name="percent" #percent="ngModel" />
-    <div [hidden]="(percent.valid || percent.pristine)"
-          class="alert alert-danger">
-      Porcentaje debe ser un número entero o decimal (punto "." es separador de decimales)
+    <div class="form-group" *ngIf="registry.type === 2">
+      <label for="percent">Porcentaje</label>
+      <input type="text" pattern="[0-9]{1,}[\.]{0,1}[0-9]{1,}" class="form-control" id="percent" required [(ngModel)]="registry.percent" name="percent" #percent="ngModel" />
+      <div [hidden]="(percent.valid || percent.pristine)"
+            class="alert alert-danger">
+        Porcentaje debe ser un número entero o decimal (punto "." es separador de decimales)
+      </div>
     </div>
-  </div>
-  
+    
+    <!--Documents section deleted/commented because Design will do this in another way
+    <div class="heading-block">
+      <h4>Documentos</h4>
+    </div>
+    <div class="panel panel-default">
+      <table class="table">
+        <thead><tr><td>Nombre</td><td></td></tr></thead>
+        <tbody>
+          <tr *ngFor="let document of registry.registry.documents">
+            <td>{{ document.name }}</td>
+            <td>
+              <button href="#" class="btn btn-danger btn-xs" (click)="deleteDocument(document)" > <span class="glyphicon glyphicon-trash"> </span> </button>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+    -->
+    <div class="modal-footer"> <!--modal-footer needed, in other case, the button will be outside the modal-->
+      <button type="submit" class="btn btn-success pull-right" [disabled]="!registryEditForm.form.valid">Editar</button>
+    </div>
+  </form>
+</div>
 
-  <div class="heading-block">
-    <h4>Documentos</h4>
-  </div>
-  <div class="panel panel-default">
-    <table class="table">
-      <thead><tr><td>Nombre</td><td>Opciones</td></tr></thead>
-      <tbody>
-        <tr *ngFor="let document of registry.registry.documents">
-          <td>{{ document.name }}</td>
-          <td>
-            <button href="#" class="btn btn-danger btn-xs" > <span class="glyphicon glyphicon-trash"> </span> </button>
-          </td>
-        </tr>
-      </tbody>
-    </table>
-  </div>
-
-  <div class="modal-footer">
-    <button type="submit" class="btn btn-success pull-right" [disabled]="!registryEditForm.form.valid">Editar</button>
-  </div>
-</form>
-
+    

--- a/ClientApp/src/app/components/indicator-detail/registry-editor/registry-editor.component.html
+++ b/ClientApp/src/app/components/indicator-detail/registry-editor/registry-editor.component.html
@@ -40,8 +40,10 @@
 
   </form>
 </div>
+<!--
 <ng-template #noRegistry>
   <em>
     Registro no seleccionado.
   </em>
 </ng-template>
+-->

--- a/ClientApp/src/app/components/indicator-detail/registry-editor/registry-editor.component.html
+++ b/ClientApp/src/app/components/indicator-detail/registry-editor/registry-editor.component.html
@@ -40,9 +40,6 @@
 
   </form>
 </div>
-
-{{registry.registry | json}}
-
 <ng-template #noRegistry>
   <em>
     Registro no seleccionado.

--- a/ClientApp/src/app/components/indicator-detail/registry-editor/registry-editor.component.html
+++ b/ClientApp/src/app/components/indicator-detail/registry-editor/registry-editor.component.html
@@ -34,8 +34,27 @@
       Porcentaje debe ser un número entero o decimal (punto "." es separador de decimales)
     </div>
   </div>
+  
+
+  <div class="heading-block">
+    <h4>Documentos</h4>
+  </div>
+  <div class="panel panel-default">
+    <table class="table">
+      <thead><tr><td>Nombre</td><td>Opciones</td></tr></thead>
+      <tbody>
+        <tr *ngFor="let document of registry.registry.documents">
+          <td>{{ document.name }}</td>
+          <td>
+            <button href="#" class="btn btn-danger btn-xs" > <span class="glyphicon glyphicon-trash"> </span> </button>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+
   <div class="modal-footer">
     <button type="submit" class="btn btn-success pull-right" [disabled]="!registryEditForm.form.valid">Editar</button>
   </div>
-
 </form>
+

--- a/ClientApp/src/app/components/indicator-detail/registry-editor/registry-editor.component.html
+++ b/ClientApp/src/app/components/indicator-detail/registry-editor/registry-editor.component.html
@@ -1,49 +1,41 @@
-<div class="container" *ngIf="registry; else noRegistry;">
-  <h2>Editar Registro</h2>
-  <form (ngSubmit)="editRegistry()" #registryEditForm="ngForm">
-    <div class="form-group">
-      <label for="name">Nombre</label>
-      <input type="text" class="form-control" id="name" required [(ngModel)]="registry.registry.name" name="name" #name="ngModel" />
-      <div [hidden]="name.valid || name.pristine"
-           class="alert alert-danger">
-        Nombre no puede estar vacio
-      </div>
+<form (ngSubmit)="editRegistry()" #registryEditForm="ngForm">
+  <div class="form-group">
+    <label for="name">Nombre</label>
+    <input type="text" class="form-control" id="name" required [(ngModel)]="registry.registry.name" name="name" #name="ngModel" />
+    <div [hidden]="name.valid || name.pristine"
+          class="alert alert-danger">
+      Nombre no puede estar vacio
     </div>
+  </div>
 
-    <div class="form-group">
-      <label for="date">Fecha</label>
-      <input type="date" class="form-control" id="date" required [(ngModel)]="registry.registry.date" name="date" #date="ngModel" />
-      <div [hidden]="(date.valid || date.pristine)"
-           class="alert alert-danger">
-        Fecha es requerida
-      </div>
+  <div class="form-group">
+    <label for="date">Fecha</label>
+    <input type="date" class="form-control" id="date" required [(ngModel)]="registry.registry.date" name="date" #date="ngModel" />
+    <div [hidden]="(date.valid || date.pristine)"
+          class="alert alert-danger">
+      Fecha es requerida
     </div>
+  </div>
 
-    <div class="form-group" *ngIf="registry.type === 1">
-      <label for="quantity">Valor</label>
-      <input type="text" pattern="[0-9]{1,}" class="form-control" id="quantity" required [(ngModel)]="registry.registry.quantity" name="quantity" #quantity="ngModel" />
-      <div [hidden]="(quantity.valid || quantity.pristine)"
-           class="alert alert-danger">
-        Cantidad deber ser un número entero
-      </div>
+  <div class="form-group" *ngIf="registry.type === 1">
+    <label for="quantity">Valor</label>
+    <input type="text" pattern="[0-9]{1,}" class="form-control" id="quantity" required [(ngModel)]="registry.registry.quantity" name="quantity" #quantity="ngModel" />
+    <div [hidden]="(quantity.valid || quantity.pristine)"
+          class="alert alert-danger">
+      Cantidad deber ser un número entero
     </div>
+  </div>
 
-    <div class="form-group" *ngIf="registry.type === 2">
-      <label for="percent">Porcentaje</label>
-      <input type="text" pattern="[0-9]{1,}[\.]{0,1}[0-9]{1,}" class="form-control" id="percent" required [(ngModel)]="registry.registry.percent" name="percent" #percent="ngModel" />
-      <div [hidden]="(percent.valid || percent.pristine)"
-           class="alert alert-danger">
-        Porcentaje debe ser un número entero o decimal (punto "." es separador de decimales)
-      </div>
+  <div class="form-group" *ngIf="registry.type === 2">
+    <label for="percent">Porcentaje</label>
+    <input type="text" pattern="[0-9]{1,}[\.]{0,1}[0-9]{1,}" class="form-control" id="percent" required [(ngModel)]="registry.registry.percent" name="percent" #percent="ngModel" />
+    <div [hidden]="(percent.valid || percent.pristine)"
+          class="alert alert-danger">
+      Porcentaje debe ser un número entero o decimal (punto "." es separador de decimales)
     </div>
+  </div>
+  <div class="modal-footer">
     <button type="submit" class="btn btn-success pull-right" [disabled]="!registryEditForm.form.valid">Editar</button>
+  </div>
 
-  </form>
-</div>
-<!--
-<ng-template #noRegistry>
-  <em>
-    Registro no seleccionado.
-  </em>
-</ng-template>
--->
+</form>

--- a/ClientApp/src/app/components/indicator-detail/registry-editor/registry-editor.component.spec.ts
+++ b/ClientApp/src/app/components/indicator-detail/registry-editor/registry-editor.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { RegistryEditorComponent } from './registry-editor.component';
+
+describe('RegistryEditorComponent', () => {
+  let component: RegistryEditorComponent;
+  let fixture: ComponentFixture<RegistryEditorComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ RegistryEditorComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(RegistryEditorComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/ClientApp/src/app/components/indicator-detail/registry-editor/registry-editor.component.ts
+++ b/ClientApp/src/app/components/indicator-detail/registry-editor/registry-editor.component.ts
@@ -1,8 +1,9 @@
-import { Component, OnInit } from '@angular/core';
-import { NgbModal, ModalDismissReasons } from '@ng-bootstrap/ng-bootstrap';
+import { Component, OnInit, Input } from '@angular/core';
+import { NgbModal, ModalDismissReasons } from '@ng-bootstrap/ng-bootstrap'; // Gonna need this
 
 import { Registry } from '../../../shared/models/registry';
 import { Indicator } from '../../../shared/models/indicator';
+import { RegistryService } from '../../../services/registry/registry.service';
 
 
 @Component({
@@ -11,30 +12,22 @@ import { Indicator } from '../../../shared/models/indicator';
   styleUrls: ['./registry-editor.component.css'],
 })
 export class RegistryEditorComponent implements OnInit {
-  closeResult: string;
 
-  constructor(private modalService: NgbModal) { }
+  @Input()
+  public registry: {registry: Registry, type: number};
 
-  ngOnInit() {}
+  private registryType: number;
 
-  open(content) {
-    /*
-    this.modalService.open(content).result.then((result) => {
-      this.closeResult = `Closed with: ${result}`;
-    }, (reason) => {
-      this.closeResult = `Dismissed ${this.getDismissReason(reason)}`;
-    });*/
-    this.modalService.open(content);
+  constructor(private modalService: NgbModal, private service: RegistryService) {
+    
   }
 
-  private getDismissReason(reason: any): string {
-    if (reason === ModalDismissReasons.ESC) {
-      return 'by pressing ESC';
-    } else if (reason === ModalDismissReasons.BACKDROP_CLICK) {
-      return 'by clicking on a backdrop';
-    } else {
-      return `with: ${reason}`;
-    }
-  }
+  ngOnInit() { }
 
+  editRegistry() {
+    console.log(this.registry.registry);
+    console.log(this.registry.registry.quantity);
+    this.service.editRegistry(this.registry.registry).subscribe();
+    this.registry = null;
+  }
 }

--- a/ClientApp/src/app/components/indicator-detail/registry-editor/registry-editor.component.ts
+++ b/ClientApp/src/app/components/indicator-detail/registry-editor/registry-editor.component.ts
@@ -18,7 +18,6 @@ export class RegistryEditorComponent implements OnInit {
 
   @Input()
   public editModalRef: BsModalRef;
-  private registryType: number;
 
   constructor(private service: RegistryService) {
     
@@ -27,8 +26,8 @@ export class RegistryEditorComponent implements OnInit {
   ngOnInit() { }
 
   editRegistry() {
+    this.service.editRegistry(this.registry.registry, this.registry.type).subscribe();
     this.editModalRef.hide();
-    this.service.editRegistry(this.registry.registry, this.registryType).subscribe();
     //this.registry = null;
     this.editModalRef = null;
   }

--- a/ClientApp/src/app/components/indicator-detail/registry-editor/registry-editor.component.ts
+++ b/ClientApp/src/app/components/indicator-detail/registry-editor/registry-editor.component.ts
@@ -1,0 +1,40 @@
+import { Component, OnInit } from '@angular/core';
+import { NgbModal, ModalDismissReasons } from '@ng-bootstrap/ng-bootstrap';
+
+import { Registry } from '../../../shared/models/registry';
+import { Indicator } from '../../../shared/models/indicator';
+
+
+@Component({
+  selector: 'app-registry-editor',
+  templateUrl: './registry-editor.component.html',
+  styleUrls: ['./registry-editor.component.css'],
+})
+export class RegistryEditorComponent implements OnInit {
+  closeResult: string;
+
+  constructor(private modalService: NgbModal) { }
+
+  ngOnInit() {}
+
+  open(content) {
+    /*
+    this.modalService.open(content).result.then((result) => {
+      this.closeResult = `Closed with: ${result}`;
+    }, (reason) => {
+      this.closeResult = `Dismissed ${this.getDismissReason(reason)}`;
+    });*/
+    this.modalService.open(content);
+  }
+
+  private getDismissReason(reason: any): string {
+    if (reason === ModalDismissReasons.ESC) {
+      return 'by pressing ESC';
+    } else if (reason === ModalDismissReasons.BACKDROP_CLICK) {
+      return 'by clicking on a backdrop';
+    } else {
+      return `with: ${reason}`;
+    }
+  }
+
+}

--- a/ClientApp/src/app/components/indicator-detail/registry-editor/registry-editor.component.ts
+++ b/ClientApp/src/app/components/indicator-detail/registry-editor/registry-editor.component.ts
@@ -5,6 +5,7 @@ import { Indicator } from '../../../shared/models/indicator';
 import { RegistryService } from '../../../services/registry/registry.service';
 import { BsModalRef } from 'ngx-bootstrap/modal';
 
+import { Document } from '../../../shared/models/document';
 
 @Component({
   selector: 'app-registry-editor',
@@ -14,21 +15,48 @@ import { BsModalRef } from 'ngx-bootstrap/modal';
 export class RegistryEditorComponent implements OnInit {
 
   @Input()
-  public registry: {registry: Registry, type: number};
+  public registry: Registry;
+
+  @Input()
+  public type: number;
 
   @Input()
   public editModalRef: BsModalRef;
 
-  constructor(private service: RegistryService) {
-    
+  public bsValue;
+
+  constructor(private service: RegistryService) {  }
+
+  ngOnInit() {
+    this.bsValue = this.registry.date;
   }
 
-  ngOnInit() { }
-
   editRegistry() {
-    this.service.editRegistry(this.registry.registry, this.registry.type).subscribe();
+    this.service.editRegistry(this.registry, this.type).subscribe();
     this.editModalRef.hide();
-    //this.registry = null;
+    // this.registry = null;
     this.editModalRef = null;
+  }
+
+  deleteDocument(document: Document) {
+    const result = confirm('Está seguro que desea elimianr el documento: ' + document.documentName);
+    if (this.registry.documents.length === 1) {
+      alert('Debe existir al menos un documento de respaldo para el registro');
+      return;
+    }
+    if (result) {
+      let removed: Document;
+      this.service.deleteDocument(document).subscribe(
+        data => {
+          removed = data;
+        },
+        err => console.error(err)
+      );
+
+      const index: number = this.registry.documents.indexOf(document);
+      if (index !== -1) {
+        this.registry.documents.splice(index,1);
+      }
+    }
   }
 }

--- a/ClientApp/src/app/components/indicator-detail/registry-editor/registry-editor.component.ts
+++ b/ClientApp/src/app/components/indicator-detail/registry-editor/registry-editor.component.ts
@@ -1,9 +1,9 @@
 import { Component, OnInit, Input } from '@angular/core';
-import { NgbModal, ModalDismissReasons } from '@ng-bootstrap/ng-bootstrap'; // Gonna need this
 
 import { Registry } from '../../../shared/models/registry';
 import { Indicator } from '../../../shared/models/indicator';
 import { RegistryService } from '../../../services/registry/registry.service';
+import { BsModalRef } from 'ngx-bootstrap/modal';
 
 
 @Component({
@@ -16,18 +16,20 @@ export class RegistryEditorComponent implements OnInit {
   @Input()
   public registry: {registry: Registry, type: number};
 
+  @Input()
+  public editModalRef: BsModalRef;
   private registryType: number;
 
-  constructor(private modalService: NgbModal, private service: RegistryService) {
+  constructor(private service: RegistryService) {
     
   }
 
   ngOnInit() { }
 
   editRegistry() {
-    console.log(this.registry.registry);
-    console.log(this.registry.registry.quantity);
+    this.editModalRef.hide();
     this.service.editRegistry(this.registry.registry, this.registryType).subscribe();
-    this.registry = null;
+    //this.registry = null;
+    this.editModalRef = null;
   }
 }

--- a/ClientApp/src/app/components/indicator-detail/registry-editor/registry-editor.component.ts
+++ b/ClientApp/src/app/components/indicator-detail/registry-editor/registry-editor.component.ts
@@ -27,7 +27,7 @@ export class RegistryEditorComponent implements OnInit {
   editRegistry() {
     console.log(this.registry.registry);
     console.log(this.registry.registry.quantity);
-    this.service.editRegistry(this.registry.registry).subscribe();
+    this.service.editRegistry(this.registry.registry, this.registryType).subscribe();
     this.registry = null;
   }
 }

--- a/ClientApp/src/app/components/indicator-home/indicator-display/indicator-display.component.html
+++ b/ClientApp/src/app/components/indicator-home/indicator-display/indicator-display.component.html
@@ -24,8 +24,7 @@
                   <div class="services-content">
                     <div class="statistic-percent" [attr.data-perc]="'indicatorResults[indicator.indicatorID-1]'">
                       <div class="fact">
-                        <span class="percentfactor" *ngIf="indicator.type === 0 || indicator.type === 1">{{ indicatorResults[indicator.indicatorID-1]}}</span>
-                        <span class="percentfactor" *ngIf="indicator.type === 2">{{ indicatorResults[indicator.indicatorID-1] | percent}}</span>
+                        <span class="percentfactor">{{ indicatorResults[indicator.indicatorID-1] }}</span> 
                         <p>{{ indicator.name }}</p>
                       </div>
                       <!-- end fact -->

--- a/ClientApp/src/app/components/indicator-home/indicator-display/indicator-display.component.html
+++ b/ClientApp/src/app/components/indicator-home/indicator-display/indicator-display.component.html
@@ -24,7 +24,8 @@
                   <div class="services-content">
                     <div class="statistic-percent" [attr.data-perc]="'indicatorResults[indicator.indicatorID-1]'">
                       <div class="fact">
-                        <span class="percentfactor">{{ indicatorResults[indicator.indicatorID-1] }}</span>
+                        <span class="percentfactor" *ngIf="indicator.type === 0 || indicator.type === 1">{{ indicatorResults[indicator.indicatorID-1]}}</span>
+                        <span class="percentfactor" *ngIf="indicator.type === 2">{{ indicatorResults[indicator.indicatorID-1] | percent}}</span>
                         <p>{{ indicator.name }}</p>
                       </div>
                       <!-- end fact -->

--- a/ClientApp/src/app/services/registry/registry.service.spec.ts
+++ b/ClientApp/src/app/services/registry/registry.service.spec.ts
@@ -1,0 +1,15 @@
+import { TestBed, inject } from '@angular/core/testing';
+
+import { RegistryService } from './registry.service';
+
+describe('RegistryService', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [RegistryService]
+    });
+  });
+
+  it('should be created', inject([RegistryService], (service: RegistryService) => {
+    expect(service).toBeTruthy();
+  }));
+});

--- a/ClientApp/src/app/services/registry/registry.service.ts
+++ b/ClientApp/src/app/services/registry/registry.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@angular/core';
 import { Registry } from '../../shared/models/registry';
 import { HttpClient, HttpErrorResponse, HttpHeaders } from '@angular/common/http';
-import { Observable } from 'rxjs';
+import { Observable } from 'rxjs/Observable';
 import { catchError, retry } from 'rxjs/operators';
 
 import { Document } from '../../shared/models/document';
@@ -11,7 +11,7 @@ export class RegistryService {
 
   private static BASE_URL = '/api/Registries/';
   private static DEFAULT = '/DefaultRegistry';
-  private static QUANTITY = '/QuantityRegistry'
+  private static QUANTITY = '/QuantityRegistry';
   private static PERCENT = '/PercentRegistry';
   private static LINK = '/LinkRegistry';
   private static ACTIVITY = '/ActivityRegistry';
@@ -23,18 +23,18 @@ private static DOCUMENTS = 'Documents/';
   editRegistry(registry: Registry, type: number): Observable<Registry> {
     const headers = new HttpHeaders()
       .append('Content-Type', 'application/json');
-    
+
     let discriminator: string = RegistryService.DEFAULT;
-    if (type == 0) {
+    if (type === 0) {
       discriminator = RegistryService.DEFAULT;
-    } else if (type == 1) {
+    } else if (type === 1) {
       discriminator = RegistryService.QUANTITY;
-    } else if (type == 2) {
+    } else if (type === 2) {
       discriminator = RegistryService.PERCENT;
-    } else if (type == 3) {
-      alert("Tipo no definido"); // LinkRegistry and ActivityRegistry types aren't defined yet - link is 3 or 4?
-    } else if (type == 4) {
-      alert ("Tipo no definido")
+    } else if (type === 3) {
+      alert('Tipo no definido'); // LinkRegistry and ActivityRegistry types aren't defined yet - link is 3 or 4?
+    } else if (type === 4) {
+      alert ('Tipo no definido');
     }
 
     return this.http.put<Registry>(RegistryService.BASE_URL + registry.registryID + discriminator, registry, { headers: headers })

--- a/ClientApp/src/app/services/registry/registry.service.ts
+++ b/ClientApp/src/app/services/registry/registry.service.ts
@@ -4,6 +4,8 @@ import { HttpClient, HttpErrorResponse, HttpHeaders } from '@angular/common/http
 import { Observable } from 'rxjs';
 import { catchError, retry } from 'rxjs/operators';
 
+import { Document } from '../../shared/models/document';
+
 @Injectable()
 export class RegistryService {
 
@@ -13,6 +15,8 @@ export class RegistryService {
   private static PERCENT = '/PercentRegistry';
   private static LINK = '/LinkRegistry';
   private static ACTIVITY = '/ActivityRegistry';
+
+private static DOCUMENTS = 'Documents/';
 
   constructor(private http: HttpClient) { }
 
@@ -37,5 +41,9 @@ export class RegistryService {
       .pipe(
       retry(5) // retry a failed request up to 3 times, but don't handle errros
       );
+  }
+
+  deleteDocument(document: Document): Observable<Document> {
+    return this.http.delete<Document>(RegistryService.BASE_URL + RegistryService.DOCUMENTS + document.documentID);
   }
 }

--- a/ClientApp/src/app/services/registry/registry.service.ts
+++ b/ClientApp/src/app/services/registry/registry.service.ts
@@ -1,0 +1,22 @@
+import { Injectable } from '@angular/core';
+import { Registry } from '../../shared/models/registry';
+import { HttpClient, HttpErrorResponse, HttpHeaders } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { catchError, retry } from 'rxjs/operators';
+
+@Injectable()
+export class RegistryService {
+
+  private static BASE_URL = '/api/Registries/';
+
+  constructor(private http: HttpClient) { }
+
+  editRegistry(registry: Registry): Observable<Registry> {
+    const headers = new HttpHeaders()
+      .append('Content-Type', 'application/json');
+    return this.http.put<Registry>(RegistryService.BASE_URL + registry.registryID, registry, { headers: headers })
+      .pipe(
+      retry(5) // retry a failed request up to 3 times, but don't handle errros
+      );
+  }
+}

--- a/ClientApp/src/app/services/registry/registry.service.ts
+++ b/ClientApp/src/app/services/registry/registry.service.ts
@@ -21,16 +21,17 @@ export class RegistryService {
       .append('Content-Type', 'application/json');
     
     let discriminator: string = RegistryService.DEFAULT;
-    if (type === 1) {
+    if (type == 0) {
+      discriminator = RegistryService.DEFAULT;
+    } else if (type == 1) {
       discriminator = RegistryService.QUANTITY;
-    } else if (type === 2) {
+    } else if (type == 2) {
       discriminator = RegistryService.PERCENT;
-    } else if (type === 3) {
-      alert("Tipo no definido");
-    } else if (type === 4) {
-      alert("Tipo no definido");
+    } else if (type == 3) {
+      alert("Tipo no definido"); // LinkRegistry and ActivityRegistry types aren't defined yet - link is 3 or 4?
+    } else if (type == 4) {
+      alert ("Tipo no definido")
     }
-
 
     return this.http.put<Registry>(RegistryService.BASE_URL + registry.registryID + discriminator, registry, { headers: headers })
       .pipe(

--- a/ClientApp/src/app/services/registry/registry.service.ts
+++ b/ClientApp/src/app/services/registry/registry.service.ts
@@ -8,13 +8,31 @@ import { catchError, retry } from 'rxjs/operators';
 export class RegistryService {
 
   private static BASE_URL = '/api/Registries/';
+  private static DEFAULT = '/DefaultRegistry';
+  private static QUANTITY = '/QuantityRegistry'
+  private static PERCENT = '/PercentRegistry';
+  private static LINK = '/LinkRegistry';
+  private static ACTIVITY = '/ActivityRegistry';
 
   constructor(private http: HttpClient) { }
 
-  editRegistry(registry: Registry): Observable<Registry> {
+  editRegistry(registry: Registry, type: number): Observable<Registry> {
     const headers = new HttpHeaders()
       .append('Content-Type', 'application/json');
-    return this.http.put<Registry>(RegistryService.BASE_URL + registry.registryID, registry, { headers: headers })
+    
+    let discriminator: string = RegistryService.DEFAULT;
+    if (type === 1) {
+      discriminator = RegistryService.QUANTITY;
+    } else if (type === 2) {
+      discriminator = RegistryService.PERCENT;
+    } else if (type === 3) {
+      alert("Tipo no definido");
+    } else if (type === 4) {
+      alert("Tipo no definido");
+    }
+
+
+    return this.http.put<Registry>(RegistryService.BASE_URL + registry.registryID + discriminator, registry, { headers: headers })
       .pipe(
       retry(5) // retry a failed request up to 3 times, but don't handle errros
       );

--- a/ClientApp/src/app/services/registry/registry.service.ts
+++ b/ClientApp/src/app/services/registry/registry.service.ts
@@ -10,11 +10,11 @@ import { Document } from '../../shared/models/document';
 export class RegistryService {
 
   private static BASE_URL = '/api/Registries/';
-  private static DEFAULT = '/DefaultRegistry';
-  private static QUANTITY = '/QuantityRegistry';
-  private static PERCENT = '/PercentRegistry';
-  private static LINK = '/LinkRegistry';
-  private static ACTIVITY = '/ActivityRegistry';
+  private static DEFAULT = 'DefaultRegistry/';
+  private static QUANTITY = 'QuantityRegistry/';
+  private static PERCENT = 'PercentRegistry/';
+  private static LINK = 'LinkRegistry/';
+  private static ACTIVITY = 'ActivityRegistry/';
 
 private static DOCUMENTS = 'Documents/';
 
@@ -37,7 +37,7 @@ private static DOCUMENTS = 'Documents/';
       alert ('Tipo no definido');
     }
 
-    return this.http.put<Registry>(RegistryService.BASE_URL + registry.registryID + discriminator, registry, { headers: headers })
+    return this.http.put<Registry>(RegistryService.BASE_URL + discriminator + registry.registryID , registry, { headers: headers })
       .pipe(
       retry(5) // retry a failed request up to 3 times, but don't handle errros
       );

--- a/ClientApp/src/app/shared/models/document.ts
+++ b/ClientApp/src/app/shared/models/document.ts
@@ -1,4 +1,5 @@
 export class Document {
+    documentID: number;
     name: string;
     documentName: string;
     extension: string;

--- a/ClientApp/src/app/shared/models/indicatorType.ts
+++ b/ClientApp/src/app/shared/models/indicatorType.ts
@@ -1,4 +1,5 @@
 export enum IndicatorType {
-    QuantityIndicatorCalculator = 0,
-    PercentIndicatorCalculator = 1,
+    DefaultIndicatorCalculator = 0,
+    QuantityIndicatorCalculator = 1,
+    PercentIndicatorCalculator = 2,
 }

--- a/ClientApp/src/app/shared/models/registry.ts
+++ b/ClientApp/src/app/shared/models/registry.ts
@@ -2,17 +2,21 @@ import { Document } from './document';
 
 export class Registry {
   registryID: number;
+  activity: string;
+  quantity: number;
+  percent: number;
+
   dateAdded: Date;
   date: Date;
   name: string;
-  value: number;
   urlDocuments: string[];
 
-  constructor(dateAdded: Date, date: Date, name: string, urlDocuments: string[], value?: number) {
+  constructor(dateAdded: Date, date: Date, name: string, urlDocuments: string[], quantity?: number, percent?: number ) {
     this.date = date;
     this.dateAdded = dateAdded;
     this.name = name;
     this.urlDocuments = urlDocuments;
-    this.value = -1;
+    this.quantity = -1;
+    this.percent = 0;
   }
 }

--- a/ClientApp/src/app/shared/models/registry.ts
+++ b/ClientApp/src/app/shared/models/registry.ts
@@ -11,6 +11,8 @@ export class Registry {
   name: string;
   urlDocuments: string[];
 
+  documents: Document[];
+
   constructor(dateAdded: Date, date: Date, name: string, urlDocuments: string[], quantity?: number, percent?: number ) {
     this.date = date;
     this.dateAdded = dateAdded;

--- a/ClientApp/src/index.html
+++ b/ClientApp/src/index.html
@@ -7,7 +7,7 @@
 
   <link href='https://fonts.googleapis.com/css?family=Open+Sans:400,400italic,600,600italic,700,700italic,300italic,300' rel='stylesheet' type='text/css'>
   <link href='http://fonts.googleapis.com/css?family=Abel' rel='stylesheet' type='text/css'>
-  
+  <link href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" rel="stylesheet">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="icon" type="image/x-icon" href="favicon.ico">
 </head>

--- a/Controllers/RegistriesController.cs
+++ b/Controllers/RegistriesController.cs
@@ -80,8 +80,8 @@ namespace think_agro_metrics.Controllers
                     throw;
                 }
             }
-
-            return NoContent();
+            return Ok();
+            //return NoContent();
         }
 
 
@@ -119,7 +119,8 @@ namespace think_agro_metrics.Controllers
                 }
             }
 
-            return NoContent();
+            return Ok();
+            //return NoContent();
         }
 
         // PUT: api/Registries/5/PercentRegistry
@@ -156,7 +157,8 @@ namespace think_agro_metrics.Controllers
                 }
             }
 
-            return NoContent();
+            return Ok();
+            //return NoContent();
         }
 
         // PUT: api/Registries/5/LinkRegistry
@@ -193,7 +195,8 @@ namespace think_agro_metrics.Controllers
                 }
             }
 
-            return NoContent();
+            return Ok();
+            //return NoContent();
         }
 
         // PUT: api/Registries/5/ActivityRegistry
@@ -230,7 +233,8 @@ namespace think_agro_metrics.Controllers
                 }
             }
 
-            return NoContent();
+            return Ok();
+            //return NoContent();
         }
 
         // POST: api/Registries

--- a/Controllers/RegistriesController.cs
+++ b/Controllers/RegistriesController.cs
@@ -47,8 +47,8 @@ namespace think_agro_metrics.Controllers
             return Ok(registry);
         }
 
-        // PUT: api/Registries/5/DefaultRegistry
-        [HttpPut("{id}/DefaultRegistry")]
+        // PUT: api/Registries/DefaultRegistry/5
+        [HttpPut("DefaultRegistry/{id}")]
         public async Task<IActionResult> PutRegistry([FromRoute] long id, [FromBody] DefaultRegistry registry)
         {   
             if (!ModelState.IsValid)
@@ -62,8 +62,6 @@ namespace think_agro_metrics.Controllers
             }
 
             _context.Entry(registry).State = EntityState.Modified;
-            //var registryDb = await _context.Registries.SingleOrDefaultAsync(r=> r.RegistryID == id);
-            //return Ok();
 
             try
             {
@@ -81,12 +79,11 @@ namespace think_agro_metrics.Controllers
                 }
             }
             return Ok();
-            //return NoContent();
         }
 
 
-        // PUT: api/Registries/5/QuantityRegistry
-        [HttpPut("{id}/QuantityRegistry")]
+        // PUT: api/Registries/QuantityRegistry/5
+        [HttpPut("QuantityRegistry/{id}")]
         public async Task<IActionResult> PutRegistry([FromRoute] long id, [FromBody] QuantityRegistry registry)
         {   
             if (!ModelState.IsValid)
@@ -100,8 +97,6 @@ namespace think_agro_metrics.Controllers
             }
 
             _context.Entry(registry).State = EntityState.Modified;
-            //var registryDb = await _context.Registries.SingleOrDefaultAsync(r=> r.RegistryID == id);
-            //return Ok();
 
             try
             {
@@ -120,11 +115,10 @@ namespace think_agro_metrics.Controllers
             }
 
             return Ok();
-            //return NoContent();
         }
 
-        // PUT: api/Registries/5/PercentRegistry
-        [HttpPut("{id}/PercentRegistry")]
+        // PUT: api/Registries/PercentRegistry/5
+        [HttpPut("PercentRegistry/{id}")]
         public async Task<IActionResult> PutRegistry([FromRoute] long id, [FromBody] PercentRegistry registry)
         {   
             if (!ModelState.IsValid)
@@ -138,8 +132,6 @@ namespace think_agro_metrics.Controllers
             }
 
             _context.Entry(registry).State = EntityState.Modified;
-            //var registryDb = await _context.Registries.SingleOrDefaultAsync(r=> r.RegistryID == id);
-            //return Ok();
 
             try
             {
@@ -158,11 +150,10 @@ namespace think_agro_metrics.Controllers
             }
 
             return Ok();
-            //return NoContent();
         }
 
-        // PUT: api/Registries/5/LinkRegistry
-        [HttpPut("{id}/LinkRegistry")]
+        // PUT: api/Registries/LinkRegistry/5
+        [HttpPut("LinkRegistry/{id}")]
         public async Task<IActionResult> PutRegistry([FromRoute] long id, [FromBody] LinkRegistry registry)
         {   
             if (!ModelState.IsValid)
@@ -176,8 +167,6 @@ namespace think_agro_metrics.Controllers
             }
 
             _context.Entry(registry).State = EntityState.Modified;
-            //var registryDb = await _context.Registries.SingleOrDefaultAsync(r=> r.RegistryID == id);
-            //return Ok();
 
             try
             {
@@ -196,11 +185,10 @@ namespace think_agro_metrics.Controllers
             }
 
             return Ok();
-            //return NoContent();
         }
 
-        // PUT: api/Registries/5/ActivityRegistry
-        [HttpPut("{id}/ActivityRegistry")]
+        // PUT: api/Registries/ActivityRegistry/5
+        [HttpPut("ActivityRegistry/{id}")]
         public async Task<IActionResult> PutRegistry([FromRoute] long id, [FromBody] ActivityRegistry registry)
         {   
             if (!ModelState.IsValid)
@@ -214,8 +202,6 @@ namespace think_agro_metrics.Controllers
             }
 
             _context.Entry(registry).State = EntityState.Modified;
-            //var registryDb = await _context.Registries.SingleOrDefaultAsync(r=> r.RegistryID == id);
-            //return Ok();
 
             try
             {
@@ -234,7 +220,6 @@ namespace think_agro_metrics.Controllers
             }
 
             return Ok();
-            //return NoContent();
         }
 
         // POST: api/Registries

--- a/Controllers/RegistriesController.cs
+++ b/Controllers/RegistriesController.cs
@@ -47,9 +47,158 @@ namespace think_agro_metrics.Controllers
             return Ok(registry);
         }
 
-        // PUT: api/Registries/5
-        [HttpPut("{id}")]
-        public async Task<IActionResult> PutRegistry([FromRoute] long id, [FromBody] Registry registry)
+        // PUT: api/Registries/5/DefaultRegistry
+        [HttpPut("{id}/DefaultRegistry")]
+        public async Task<IActionResult> PutRegistry([FromRoute] long id, [FromBody] DefaultRegistry registry)
+        {   
+            if (!ModelState.IsValid)
+            {
+                return BadRequest(ModelState);
+            }
+
+            if (id != registry.RegistryID)
+            {
+                return BadRequest();
+            }
+
+            _context.Entry(registry).State = EntityState.Modified;
+            //var registryDb = await _context.Registries.SingleOrDefaultAsync(r=> r.RegistryID == id);
+            //return Ok();
+
+            try
+            {
+                await _context.SaveChangesAsync();
+            }
+            catch (DbUpdateConcurrencyException)
+            {
+                if (!RegistryExists(id))
+                {
+                    return NotFound();
+                }
+                else
+                {
+                    throw;
+                }
+            }
+
+            return NoContent();
+        }
+
+
+        // PUT: api/Registries/5/QuantityRegistry
+        [HttpPut("{id}/QuantityRegistry")]
+        public async Task<IActionResult> PutRegistry([FromRoute] long id, [FromBody] QuantityRegistry registry)
+        {   
+            if (!ModelState.IsValid)
+            {
+                return BadRequest(ModelState);
+            }
+
+            if (id != registry.RegistryID)
+            {
+                return BadRequest();
+            }
+
+            _context.Entry(registry).State = EntityState.Modified;
+            //var registryDb = await _context.Registries.SingleOrDefaultAsync(r=> r.RegistryID == id);
+            //return Ok();
+
+            try
+            {
+                await _context.SaveChangesAsync();
+            }
+            catch (DbUpdateConcurrencyException)
+            {
+                if (!RegistryExists(id))
+                {
+                    return NotFound();
+                }
+                else
+                {
+                    throw;
+                }
+            }
+
+            return NoContent();
+        }
+
+        // PUT: api/Registries/5/PercentRegistry
+        [HttpPut("{id}/PercentRegistry")]
+        public async Task<IActionResult> PutRegistry([FromRoute] long id, [FromBody] PercentRegistry registry)
+        {   
+            if (!ModelState.IsValid)
+            {
+                return BadRequest(ModelState);
+            }
+
+            if (id != registry.RegistryID)
+            {
+                return BadRequest();
+            }
+
+            _context.Entry(registry).State = EntityState.Modified;
+            //var registryDb = await _context.Registries.SingleOrDefaultAsync(r=> r.RegistryID == id);
+            //return Ok();
+
+            try
+            {
+                await _context.SaveChangesAsync();
+            }
+            catch (DbUpdateConcurrencyException)
+            {
+                if (!RegistryExists(id))
+                {
+                    return NotFound();
+                }
+                else
+                {
+                    throw;
+                }
+            }
+
+            return NoContent();
+        }
+
+        // PUT: api/Registries/5/LinkRegistry
+        [HttpPut("{id}/LinkRegistry")]
+        public async Task<IActionResult> PutRegistry([FromRoute] long id, [FromBody] LinkRegistry registry)
+        {   
+            if (!ModelState.IsValid)
+            {
+                return BadRequest(ModelState);
+            }
+
+            if (id != registry.RegistryID)
+            {
+                return BadRequest();
+            }
+
+            _context.Entry(registry).State = EntityState.Modified;
+            //var registryDb = await _context.Registries.SingleOrDefaultAsync(r=> r.RegistryID == id);
+            //return Ok();
+
+            try
+            {
+                await _context.SaveChangesAsync();
+            }
+            catch (DbUpdateConcurrencyException)
+            {
+                if (!RegistryExists(id))
+                {
+                    return NotFound();
+                }
+                else
+                {
+                    throw;
+                }
+            }
+
+            return NoContent();
+        }
+
+        // PUT: api/Registries/5/ActivityRegistry
+        [HttpPut("{id}/ActivityRegistry")]
+        public async Task<IActionResult> PutRegistry([FromRoute] long id, [FromBody] ActivityRegistry registry)
         {   
             if (!ModelState.IsValid)
             {

--- a/Controllers/RegistriesController.cs
+++ b/Controllers/RegistriesController.cs
@@ -252,6 +252,35 @@ namespace think_agro_metrics.Controllers
             return CreatedAtAction("GetRegistry", new { id = registry.RegistryID }, registry);
         }
 
+        // DELETE: api/Registries/Documents/5
+        [HttpDelete("Documents/{id}")]
+        public async Task<IActionResult> DeleteDocument([FromRoute] long id)
+        {
+            if(!ModelState.IsValid)
+            {
+                return BadRequest(ModelState);
+            }
+
+            var document = await _context.Documents.SingleOrDefaultAsync(d => d.DocumentID == id );
+            
+            if(document == null)
+            {
+                return NotFound();
+            }
+            
+            // Every documents belongs to a Registry, it's not necessary to validate
+            var registry = await _context.Registries.SingleOrDefaultAsync(r => r.RegistryID == document.RegistryID);
+
+            registry.Documents.Remove(document); // Delete Document from model
+
+            _context.Documents.Remove(document); // Delete Document from Database
+
+            await _context.SaveChangesAsync();
+
+            return Ok(document);
+
+        }
+
         // DELETE: api/Registries/5
         [HttpDelete("{id}")]
         public async Task<IActionResult> DeleteRegistry([FromRoute] long id)
@@ -266,8 +295,7 @@ namespace think_agro_metrics.Controllers
             {
                 return NotFound();
             }
-
-            //var documents = _context.Documents.Where(d => d.RegistryID == id);
+            
             var documents = registry.Documents;
             foreach (Document document in documents) // Remove documents from model
             {

--- a/Controllers/RegistriesController.cs
+++ b/Controllers/RegistriesController.cs
@@ -50,7 +50,7 @@ namespace think_agro_metrics.Controllers
         // PUT: api/Registries/5
         [HttpPut("{id}")]
         public async Task<IActionResult> PutRegistry([FromRoute] long id, [FromBody] Registry registry)
-        {
+        {   
             if (!ModelState.IsValid)
             {
                 return BadRequest(ModelState);
@@ -62,6 +62,8 @@ namespace think_agro_metrics.Controllers
             }
 
             _context.Entry(registry).State = EntityState.Modified;
+            //var registryDb = await _context.Registries.SingleOrDefaultAsync(r=> r.RegistryID == id);
+            //return Ok();
 
             try
             {

--- a/Data/DataContext.cs
+++ b/Data/DataContext.cs
@@ -53,6 +53,7 @@ namespace think_agro_metrics.Data
             modelBuilder.Entity<DefaultRegistry>();
             modelBuilder.Entity<ActivityRegistry>();
             modelBuilder.Entity<QuantityRegistry>();
+            modelBuilder.Entity<PercentRegistry>();
             modelBuilder.Entity<LinkRegistry>();
         }
 

--- a/Data/DataContext.cs
+++ b/Data/DataContext.cs
@@ -35,7 +35,7 @@ namespace think_agro_metrics.Data
             //comienzo  de la jerarquia en SMSS
             //El campo Database corresponde al nombre de  la base de datos a utilizar.
             //El otro ponganlo because of reasons.
-            optionsBuilder.UseSqlServer("Server=.\\SQLEXPRESS01;Database=think_agro_metrics;Trusted_Connection=True;");
+            optionsBuilder.UseSqlServer("Server=.\\SQLEXPRESS;Database=think_agro_metrics;Trusted_Connection=True;");
         }
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)

--- a/Data/DataContext.cs
+++ b/Data/DataContext.cs
@@ -35,7 +35,7 @@ namespace think_agro_metrics.Data
             //comienzo  de la jerarquia en SMSS
             //El campo Database corresponde al nombre de  la base de datos a utilizar.
             //El otro ponganlo because of reasons.
-            optionsBuilder.UseSqlServer("Server=.\\SQLEXPRESS;Database=think_agro_metrics;Trusted_Connection=True;");
+            optionsBuilder.UseSqlServer("Server=.\\SQLEXPRESS01;Database=think_agro_metrics;Trusted_Connection=True;");
         }
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)

--- a/Data/DbInitializer.cs
+++ b/Data/DbInitializer.cs
@@ -140,44 +140,44 @@ namespace think_agro_metrics.Data
 
             var registries4c = new Registry[]
             {
-                new QuantityRegistry{
+                new PercentRegistry{
                     Name = "Dole",
                     Date = DateTime.Today,
-                    Quantity = 25,
+                    Percent = 25,
                     Documents = null //documents4c1
                 },
 
-                new QuantityRegistry
+                new PercentRegistry
                 {
                     Name = "Santa Margarita",
                     Date = DateTime.Today,
-                    Quantity = 17,
+                    Percent = 17,
                     Documents = null //documents4c2
                 }
             };
 
             var registries4d = new Registry[]
             {
-                new QuantityRegistry{
+                new PercentRegistry{
                     Name = "Dole",
                     Date = DateTime.Today,
-                    Quantity = 25,
+                    Percent = 25,
                     Documents = null //documents4d1
                 },
 
-                new QuantityRegistry
+                new PercentRegistry
                 {
                     Name = "Santa Margarita",
                     Date = DateTime.Today,
-                    Quantity = 17,
+                    Percent = 17,
                     Documents = null //documents4d2
                 },
 
-                new QuantityRegistry
+                new PercentRegistry
                 {
                     Name = "Tio Genaro",
                     Date = DateTime.Today,
-                    Quantity = 40,
+                    Percent = 40,
                     Documents = null //documents4d3
                 }
             };

--- a/Models/PercentIndicatorCalculator.cs
+++ b/Models/PercentIndicatorCalculator.cs
@@ -9,13 +9,21 @@ namespace think_agro_metrics.Models
     {
         public double Calculate(ICollection<Registry> registries)
         {
-            int sum = 0;
+            double sum = 0.0;
             int quantity = 0;
             foreach (Registry registry in registries) {
-                sum += (registry as QuantityRegistry).Quantity;
-                quantity++;
+                if(registry.GetType() == typeof(PercentRegistry))
+                {
+                    sum += (registry as PercentRegistry).Percent;
+                    quantity++;
+                }
+                else if (registry.GetType() == typeof(QuantityRegistry)) { // This isn't necessary, but it works
+                    sum += (registry as QuantityRegistry).Quantity;
+                    quantity++;
+                }
+                
             }
-            return sum / quantity;
+            return Math.Round((sum / quantity)/100, 2);
         }
     }
 }

--- a/Models/PercentRegistry.cs
+++ b/Models/PercentRegistry.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace think_agro_metrics.Models
+{
+    public class PercentRegistry : Registry
+    {
+        public int Percent { get; set; }
+
+        public PercentRegistry() { }
+    }
+}


### PR DESCRIPTION
### Important
- I've merged `staging` into this branch just to *prepare* the PR (@Alisboa13's advice).
- Updates on Database.

#### New dependencies
- `ngx-bootstrap` - Edit Modal

#### Adds
1. Modal for edit a registry.
2. List of documents and functionality to delete a document.
3. `RegistryService`, to edit a `Registry` (independent from `Indicator`) and to delete a `Document` (dependent from `Registry`).

#### Problems or not supported
- `LinkRegistry` and `ActivityRegistry` are not totally supported by edit-form and edit-service.
- When modal starts, actual date (of registry) on Datepicker don't get showed (`dd-mm-aaaa` instead) but if you click edit without changing that date, it won't get changed.

#### Explanations 
1. Modal for edit a registry `registry-editor`, gets triggered on `indicator-detail` from edit button (in a future design, this modal maybe will gets triggered from other button in another position).
Supports `DefaultRegistry`, `QuantityRegistry` and `PercentRegistry`. `LinkRegistry` and `ActivityRegistry` need some definitions before. 
I've had to modify `RegistriesController` (error: 400). It works, don't judge me.
2. A list of documents in `indicator-detail`, there is a delete button to delete a document from a registry. Just for *demo purpose*. Felipe has to *add a document*, so he could add a button here to add that document. **Just for demo purpose**, will be deleted in some time at the future. Daniela has plans for this list of registries and documents.
3. I think that this is the place where these methods belongs.
