### PR TITLE
feat(CalculateMonth)

### DIFF
--- a/ClientApp/package.json
+++ b/ClientApp/package.json
@@ -31,6 +31,7 @@
     "bootstrap": "^3.3.7",
     "core-js": "^2.4.1",
     "font-awesome": "^4.3.0",
+    "ngx-bootstrap": "^2.0.5",
     "rxjs": "^5.5.6",
     "zone.js": "^0.8.19"
   },

--- a/ClientApp/src/app/app.module.ts
+++ b/ClientApp/src/app/app.module.ts
@@ -5,6 +5,7 @@ import { HttpClientModule } from '@angular/common/http';
 import { RouterModule } from '@angular/router';
 
 import { AppComponent } from './app.component';
+import { BsDropdownModule } from 'ngx-bootstrap/dropdown';
 import { HeaderComponent } from './components/header/header.component';
 import { FooterComponent } from './components/footer/footer.component';
 import { IndicatorHomeComponent } from './components/indicator-home/indicator-home.component';
@@ -29,6 +30,7 @@ import { IndicatorGroupService } from './services/indicator-group/indicator-grou
     ResultHomeComponent
   ],
   imports: [
+    BsDropdownModule.forRoot(),
     NgbModule.forRoot(),
     BrowserModule.withServerTransition({ appId: 'ng-cli-universal' }),
     HttpClientModule,

--- a/ClientApp/src/app/components/indicator-home/indicator-display/indicator-display.component.html
+++ b/ClientApp/src/app/components/indicator-home/indicator-display/indicator-display.component.html
@@ -5,34 +5,46 @@
         <h2>{{ indicatorGroup.name }}</h2>
       </div>
 
-      <!--Dropdown Year Filter-->
-      Seleccione los años a calcular:
-      <div ngbDropdown class="d-inline-block dropdown">
-        <button class="btn btn-primary" id="dropdownYear" ngbDropdownToggle>{{ selectionYear }} <i class="fa fa-caret-down"></i> </button>             
-        <ul class="dropdown-menu" ngbDropdownMenu aria-labelledby="dropdownYear">          
-          <li><a class="dropdown-item" (click)="calcularIndicadores('Todos los años')">Todos los años</a></li>          
-          <li *ngFor="let year of years">
-            <a class="dropdown-item" (click)="calculateIndicadors(year)">Año {{ year }}</a>
-          </li>          
-        </ul>
+      <!--Dropdown Filters-->
+      <div class="row">
+        <!--Dropdown Year Filter-->
+        <div class="col-md-6">          
+          Seleccione los años a calcular:
+          <br>
+          <div class="btn-group" dropdown>
+            <button id="button-basic" dropdownToggle type="button" class="btn btn-primary dropdown-toggle" aria-controls="dropdown-basic">
+              {{ selectionYear }} <span class="caret"></span>
+            </button>
+            <ul id="dropdown-basic" *dropdownMenu class="dropdown-menu"
+                role="menu" aria-labelledby="button-basic">
+              <li ><a class="dropdown-item" (click)="calculateIndicators(allYears, '')">Todos los años</a></li>          
+              <li *ngFor="let year of years"><a class="dropdown-item" (click)="calculateIndicators(year, '')">Año {{ year }}</a></li>
+            </ul>
+          </div>
+        </div>
+        <!--Dropdown Month Filter-->
+        <div class="col-md-6">
+          Seleccione los meses a calcular:
+          <br>
+          <div class="btn-group" dropdown [isDisabled]="isMonthDisabled">
+            <button id="button-basic" dropdownToggle type="button" class="btn btn-primary dropdown-toggle" aria-controls="dropdown-basic">
+              {{ selectionMonth }} <span class="caret"></span>
+            </button>
+            <ul id="dropdown-basic" *dropdownMenu class="dropdown-menu"
+                role="menu" aria-labelledby="button-basic">
+              <li ><a class="dropdown-item" (click)="calculateIndicators('', allMonths)">Todos los meses</a></li>          
+              <li *ngFor="let month of monthsOfTheYear"><a class="dropdown-item" (click)="calculateIndicators('', month)">{{ month }}</a></li>
+            </ul>
+          </div>
+        </div>
       </div>
-      <br>
 
-      <!--Dropdown Month Filter-->
-      Seleccione los años a calcular:
-      <div ngbDropdown class="d-inline-block dropdown">
-        <button class="btn btn-primary" id="dropdownMonth" ngbDropdownToggle>{{ selectionMonth }} <i class="fa fa-caret-down"></i> </button>             
-        <ul class="dropdown-menu" ngbDropdownMenu aria-labelledby="dropdownMonth">          
-          <li><a class="dropdown-item" (click)="calcularIndicadores('Todos los años')">Todos los años</a></li>          
-          <li *ngFor="let year of years"><a class="dropdown-item" (click)="calcularIndicadores(year)">Año {{ year }}</a></li>          
-        </ul>
-      </div>
-      <br>
 
       <!-- end col-md-12 -->
     </div>
     <!-- end container -->
   </section>
+  <br>
   <!-- end page-section -->
   <section>
     <div id="statistic-section" class="statistic-bg" data-stellar-background-ratio="0">
@@ -46,14 +58,14 @@
             <div class="col-xs-6 col-sm-3 col-md-4">
               <a class="active" href="/indicator/{{ indicator.indicatorID }}">
                 <div class="services-content">
-                  <div class="statistic-percent" [attr.data-perc]="'indicatorResults[indicator.indicatorID-1]'">
+                  <div class="statistic-percent" [attr.data-perc]="indicatorResults[i]">
                     <div class="fact">
 
                       <div *ngIf="indicator.type == 2; else noPercent">
-                        <span class="percentfactor">{{ indicatorResults[indicator.indicatorID-1] | number:'.0-2'}}%</span>
+                        <span class="percentfactor">{{ indicatorResults[i] | number:'.0-2'}}%</span>
                       </div>
                       <ng-template #noPercent>
-                         <span class="percentfactor">{{ indicatorResults[indicator.indicatorID-1] | number:'.0-2'}}</span>
+                         <span class="percentfactor">{{ indicatorResults[i] | number:'.0-2'}}</span>
                       </ng-template>
                       
                       <p>{{ indicator.name }}</p>

--- a/ClientApp/src/app/components/indicator-home/indicator-display/indicator-display.component.html
+++ b/ClientApp/src/app/components/indicator-home/indicator-display/indicator-display.component.html
@@ -8,8 +8,21 @@
       <!--Dropdown Year Filter-->
       Seleccione los años a calcular:
       <div ngbDropdown class="d-inline-block dropdown">
-        <button class="btn btn-primary" id="dropdownBasic1" ngbDropdownToggle>{{ selection }} <i class="fa fa-caret-down"></i> </button>             
-        <ul class="dropdown-menu" ngbDropdownMenu aria-labelledby="dropdownBasic1">          
+        <button class="btn btn-primary" id="dropdownYear" ngbDropdownToggle>{{ selectionYear }} <i class="fa fa-caret-down"></i> </button>             
+        <ul class="dropdown-menu" ngbDropdownMenu aria-labelledby="dropdownYear">          
+          <li><a class="dropdown-item" (click)="calcularIndicadores('Todos los años')">Todos los años</a></li>          
+          <li *ngFor="let year of years">
+            <a class="dropdown-item" (click)="calculateIndicadors(year)">Año {{ year }}</a>
+          </li>          
+        </ul>
+      </div>
+      <br>
+
+      <!--Dropdown Month Filter-->
+      Seleccione los años a calcular:
+      <div ngbDropdown class="d-inline-block dropdown">
+        <button class="btn btn-primary" id="dropdownMonth" ngbDropdownToggle>{{ selectionMonth }} <i class="fa fa-caret-down"></i> </button>             
+        <ul class="dropdown-menu" ngbDropdownMenu aria-labelledby="dropdownMonth">          
           <li><a class="dropdown-item" (click)="calcularIndicadores('Todos los años')">Todos los años</a></li>          
           <li *ngFor="let year of years"><a class="dropdown-item" (click)="calcularIndicadores(year)">Año {{ year }}</a></li>          
         </ul>

--- a/ClientApp/src/app/components/indicator-home/indicator-display/indicator-display.component.ts
+++ b/ClientApp/src/app/components/indicator-home/indicator-display/indicator-display.component.ts
@@ -16,8 +16,11 @@ import { IndicatorService } from '../../../services/indicator/indicator.service'
 export class IndicatorDisplayComponent implements OnInit {
   @Input() indicatorGroup;
   indicatorResults$: Observable<number[]>;
-  selection = 'Todos los años';
+  selectionYear: string; // Default selection = currentYear (defined in ngOnInit)
+  selectionMonth: 'Todos los meses'; // Default selection
   years: number[] = []; // List of the years from baseYear to currentYear (defined in ngOnInit)
+  months: number[] = []; // List of the months from 0 (January) to the current month (defined in ngOnInit)
+  monthsOfTheYear: string[] = []; // List with the list of the months of the selected year (defined in ngOnInit)
 
   constructor(private service: IndicatorService) {
   }
@@ -31,17 +34,66 @@ export class IndicatorDisplayComponent implements OnInit {
     for (let i = 0; i <= (currentYear - baseYear); i++) {
         this.years[i] = baseYear + i;
     }
-  }
+    this.selectionYear = 'Año ' + currentYear;
 
-  calcularIndicadores(value: any) {
-    if (value === 'Todos los años') {
-      this.indicatorResults$ = this.service.calculateIndicators();
-      this.selection = value;
-    } else {
-      this.indicatorResults$ = this.service.calculateIndicatorsYear(value);
-      this.selection = 'Año ' + value;
+    const currentMonth = new Date().getMonth(); // 0 = Juanuary, 1 = February, ..., 11 = December
+    for (let i = 0; i <= currentMonth; i++) {
+      this.months[i] = i;
     }
+    this.setMonthsOfTheYear();
 
   }
 
+  calculateIndicadors(year: any, month: any) {
+    if (year === 'Todos los años') {
+      this.indicatorResults$ = this.service.calculateIndicators();
+      this.selectionYear = year;
+    } else {
+      this.indicatorResults$ = this.service.calculateIndicatorsYear(year);
+      this.selectionYear = 'Año ' + year;
+    }
+  }
+
+  setMonthsOfTheYear() {
+    this.months.forEach(month => {
+      switch (month) {
+        case 0:
+          this.monthsOfTheYear.concat('Enero');
+          break;
+        case 1:
+          this.monthsOfTheYear.concat('Febrero');
+          break;
+        case 2:
+          this.monthsOfTheYear.concat('Marzo');
+          break;
+        case 3:
+          this.monthsOfTheYear.concat('Abril');
+          break;
+        case 4:
+          this.monthsOfTheYear.concat('Mayo');
+          break;
+        case 5:
+          this.monthsOfTheYear.concat('Junio');
+          break;
+        case 6:
+          this.monthsOfTheYear.concat('Julio');
+          break;
+        case 7:
+          this.monthsOfTheYear.concat('Agosto');
+          break;
+        case 8:
+          this.monthsOfTheYear.concat('Semptiembre');
+          break;
+        case 9:
+          this.monthsOfTheYear.concat('Octubre');
+          break;
+        case 10:
+          this.monthsOfTheYear.concat('Noviembre');
+          break;
+        case 11:
+          this.monthsOfTheYear.concat('Diciembre');
+          break;
+      }
+    });
+  }
 }

--- a/ClientApp/src/app/components/indicator-home/indicator-display/indicator-display.component.ts
+++ b/ClientApp/src/app/components/indicator-home/indicator-display/indicator-display.component.ts
@@ -6,7 +6,8 @@ import { DecimalPipe } from '@angular/common';
 import { Indicator } from '../../../shared/models/indicator';
 
 // Service
-import { IndicatorService } from '../../../services/indicator/indicator.service';
+import { IndicatorGroupService } from '../../../services/indicator-group/indicator-group.service';
+import { IndicatorGroup } from '../../../shared/models/indicatorGroup';
 
 @Component({
   selector: 'app-indicator-display',
@@ -14,86 +15,110 @@ import { IndicatorService } from '../../../services/indicator/indicator.service'
   styleUrls: ['./indicator-display.component.css']
 })
 export class IndicatorDisplayComponent implements OnInit {
-  @Input() indicatorGroup;
-  indicatorResults$: Observable<number[]>;
-  selectionYear: string; // Default selection = currentYear (defined in ngOnInit)
-  selectionMonth: 'Todos los meses'; // Default selection
-  years: number[] = []; // List of the years from baseYear to currentYear (defined in ngOnInit)
-  months: number[] = []; // List of the months from 0 (January) to the current month (defined in ngOnInit)
-  monthsOfTheYear: string[] = []; // List with the list of the months of the selected year (defined in ngOnInit)
+  private static ALL_YEARS = 'Todos los años';
+  private static ALL_MONTHS = 'Todos los meses';
+  private static YEAR = 'Año '; // In the front of the selected year (e.g.: 'Año 2018')
+  // Used in the html to keep the consistency
+  allYears: string = IndicatorDisplayComponent.ALL_YEARS;
+  allMonths: string = IndicatorDisplayComponent.ALL_MONTHS;
 
-  constructor(private service: IndicatorService) {
+  @Input() indicatorGroup: IndicatorGroup;
+  indicatorResults$: Observable<number[]>;
+  selectionYear: string; // Default selection = currentYear (defined in ngOnInit) (string shown in the dropdown)
+  // tslint:disable-next-line:max-line-length
+  selectionMonth: string = IndicatorDisplayComponent.ALL_MONTHS; // Default selection (string shown in the dropdown)
+  selectedYear: number; // The current selected year (number), by default = currentYear (defined in ngOnInit)
+  selectedMonth: number; // The current selected month (number), depends of the name of the month in spanish.
+  years: number[] = []; // List of the years from baseYear to currentYear (defined in ngOnInit)
+  // tslint:disable-next-line:max-line-length
+  monthsNames: string[] = ['Enero', 'Febrero', 'Marzo', 'Abril', 'Mayo', 'Junio', 'Julio', 'Agosto', 'Septiembre', 'Octubre', 'Noviembre', 'Diciembre'];
+  months: number[] = []; // List of the months from 0 (January) to the current month (defined in ngOnInit)
+  monthsOfTheYear: string[] = []; // List with the list names of the months (in spanish) of the selected year (defined in ngOnInit)
+  isMonthDisabled = false;  // Set 'true' when ALL_YEARS is selected. In other case, set false.
+
+  constructor(private service: IndicatorGroupService) {
   }
 
   ngOnInit() {
-    this.indicatorResults$ = this.service.calculateIndicators();
+    const currentYear = new Date().getFullYear();
+    this.indicatorResults$ = this.service.calculateIndicatorGroupYear(this.indicatorGroup.indicatorGroupID, currentYear);
 
     // Create the list of years from baseYear to currentYear
-    const baseYear = 2018;
-    const currentYear = new Date().getFullYear();
+    const baseYear = 2018; // Year in which this project began
     for (let i = 0; i <= (currentYear - baseYear); i++) {
         this.years[i] = baseYear + i;
     }
-    this.selectionYear = 'Año ' + currentYear;
+    this.selectionYear = IndicatorDisplayComponent.YEAR + currentYear; // By default the current year is shown
+    this.selectedYear = currentYear; // The number of the selected year (by default the current year)
 
     const currentMonth = new Date().getMonth(); // 0 = Juanuary, 1 = February, ..., 11 = December
+    // List of the months (numbers) from 0 to the current month (max 11)
     for (let i = 0; i <= currentMonth; i++) {
       this.months[i] = i;
     }
-    this.setMonthsOfTheYear();
-
+    this.setMonthsOfTheYear(); // List of the names of the months, based in the prior list (this.months)
+    this.selectionMonth = IndicatorDisplayComponent.ALL_MONTHS; // By default ALL_MONTHS is shown
+    this.selectedMonth = -1; // It's not selected a specific month yet
   }
 
-  calculateIndicadors(year: any, month: any) {
-    if (year === 'Todos los años') {
-      this.indicatorResults$ = this.service.calculateIndicators();
-      this.selectionYear = year;
-    } else {
-      this.indicatorResults$ = this.service.calculateIndicatorsYear(year);
-      this.selectionYear = 'Año ' + year;
+  // Only specify the year or the month, depending on which one is changed, the other value must be an empty string ('')
+  calculateIndicators(year: any, month: string) { // The 'year' is of type 'any' because it's used as 'int' and 'string'
+    // The change is in the year
+    if ((year as string).length !== 0) {
+      // ALL_YEARS selected
+      if (year === IndicatorDisplayComponent.ALL_YEARS) {
+        this.indicatorResults$ = this.service.calculateIndicatorGroup(this.indicatorGroup.indicatorGroupID); // Calculate for all the years
+        this.selectionYear = IndicatorDisplayComponent.ALL_YEARS; // Change the value shown in the dropdown
+        this.isMonthDisabled = true;  // Not able to select a month
+        this.selectedYear = -1; // Not selected a specific year
+      }
+      // Selected a specific year
+      // tslint:disable-next-line:one-line
+      else {
+        // tslint:disable-next-line:max-line-length
+        this.indicatorResults$ = this.service.calculateIndicatorGroupYear(this.indicatorGroup.indicatorGroupID, year); // Calculate for the specific year
+        this.selectionYear = IndicatorDisplayComponent.YEAR + year; // Change the value shown in the dropdown
+        this.isMonthDisabled = false; // It's possible to select a month
+        this.selectedYear = year;
+      }
+      this.selectionMonth = IndicatorDisplayComponent.ALL_MONTHS;
+    }
+    // The change is in the month
+    // tslint:disable-next-line:one-line
+    else {
+      // All the months of the already selected year
+      if (month === IndicatorDisplayComponent.ALL_MONTHS) {
+        this.selectedMonth = -1; // Not selected a specific month
+        // tslint:disable-next-line:max-line-length
+        this.indicatorResults$ = this.service.calculateIndicatorGroupYear(this.indicatorGroup.indicatorGroupID, this.selectedYear); // Calculate for the already selected year
+        this.selectionMonth = IndicatorDisplayComponent.ALL_MONTHS; // Change the value shown in the dropdown
+      }
+      // Selected a specific month of the already selected year
+      // tslint:disable-next-line:one-line
+      else {
+        this.setSelectedMonth(month); // Set the numeric value of the month as selected (needed for the calculation)
+        // Do the calculation for the already selected year and month
+        // tslint:disable-next-line:max-line-length
+        this.indicatorResults$ = this.service.calculateIndicatorGroupYearMonth(this.indicatorGroup.indicatorGroupID, this.selectedYear, this.selectedMonth);
+        this.selectionMonth = this.monthsNames[this.selectedMonth]; // Change the value shown in the dropdown
+      }
     }
   }
 
+  // Sets the names of the months of the selected year
   setMonthsOfTheYear() {
     this.months.forEach(month => {
-      switch (month) {
-        case 0:
-          this.monthsOfTheYear.concat('Enero');
-          break;
-        case 1:
-          this.monthsOfTheYear.concat('Febrero');
-          break;
-        case 2:
-          this.monthsOfTheYear.concat('Marzo');
-          break;
-        case 3:
-          this.monthsOfTheYear.concat('Abril');
-          break;
-        case 4:
-          this.monthsOfTheYear.concat('Mayo');
-          break;
-        case 5:
-          this.monthsOfTheYear.concat('Junio');
-          break;
-        case 6:
-          this.monthsOfTheYear.concat('Julio');
-          break;
-        case 7:
-          this.monthsOfTheYear.concat('Agosto');
-          break;
-        case 8:
-          this.monthsOfTheYear.concat('Semptiembre');
-          break;
-        case 9:
-          this.monthsOfTheYear.concat('Octubre');
-          break;
-        case 10:
-          this.monthsOfTheYear.concat('Noviembre');
-          break;
-        case 11:
-          this.monthsOfTheYear.concat('Diciembre');
-          break;
-      }
+      this.monthsOfTheYear[month] = this.monthsNames[month];
     });
+  }
+
+  // According to the name of a month, it sets the corresponding number to the 'selectedMonth'
+  setSelectedMonth(month: string) {
+    for (let index = 0; index < this.monthsNames.length; index++) {
+      if (month === this.monthsNames[index]) {
+        this.selectedMonth = index;
+        return;
+      }
+    }
   }
 }

--- a/ClientApp/src/app/services/indicator-group/indicator-group.service.ts
+++ b/ClientApp/src/app/services/indicator-group/indicator-group.service.ts
@@ -10,6 +10,7 @@ import { IndicatorGroup } from '../../shared/models/indicatorGroup';
 export class IndicatorGroupService {
 
   public static API_URL = 'api/IndicatorGroups/';
+  public static CALCULATE = IndicatorGroupService.API_URL + 'Calculate/';
 
   constructor(public http: HttpClient) { }
 
@@ -19,6 +20,18 @@ export class IndicatorGroupService {
 
   getIndicatorGroup(indicatorGroupId: number | string): Observable<IndicatorGroup> {
     return this.http.get<IndicatorGroup>(IndicatorGroupService.API_URL + indicatorGroupId);
+  }
+
+  calculateIndicatorGroup(indicatorGroup: number): Observable<number[]> {
+    return this.http.get<number[]>(IndicatorGroupService.CALCULATE + indicatorGroup);
+  }
+
+  calculateIndicatorGroupYear(indicatorGroup: number, year: number): Observable<number[]> {
+    return this.http.get<number[]>(IndicatorGroupService.CALCULATE + indicatorGroup + '/' + year);
+  }
+
+  calculateIndicatorGroupYearMonth(indicatorGroup: number, year: number, month: number): Observable<number[]> {
+    return this.http.get<number[]>(IndicatorGroupService.CALCULATE + indicatorGroup + '/' + year + '/' + month);
   }
 
 }

--- a/Controllers/IndicatorGroupsController.cs
+++ b/Controllers/IndicatorGroupsController.cs
@@ -121,6 +121,114 @@ namespace think_agro_metrics.Controllers
             return Ok(indicatorGroup);
         }
 
+        // GET: api/IndicatorGroups/Calculate/1 (group= 1)
+        [Route("Calculate/{id:int}")]
+        public async Task<IActionResult> CalculateIndicators([FromRoute] int id)
+        {
+            if (!ModelState.IsValid)
+            {
+                return BadRequest(ModelState);
+            }
+
+            // Load from the DB the IndicatorGroups with its Indicators, Registries, Documents, and Links
+            _context.IndicatorGroups.Include(x => x.Indicators)
+                .ThenInclude(x => x.Registries).ToList();
+            _context.LinkRegistries.Include(x => x.Links).ToList();
+
+            var indicatorGroup = await _context.IndicatorGroups.SingleOrDefaultAsync(m => m.IndicatorGroupID == id);
+            
+            // If the specified indicator group doesn't exist, show NotFound
+            if (indicatorGroup == null)
+            {
+                return NotFound();
+            }
+
+            // List of the results of every indicator of the group
+            List<double> list = new List<double>();
+
+            // Calculate every indicator of the group
+            foreach (Indicator indicator in indicatorGroup.Indicators)
+            {
+                indicator.Type = indicator.Type; // Assign the IndicatorCalculator according to the Indicator's Type
+                list.Add(indicator.IndicatorCalculator.Calculate(indicator.Registries));
+            }
+
+            // Return the list with the results
+            return Ok(list);
+        }
+
+        // GET: api/IndicatorGroups/Calculate/1/2018 (group= 1, year= 2018)
+        [Route("Calculate/{id:int}/{year:int}")]
+        public async Task<IActionResult> CalculateIndicators([FromRoute] int id, [FromRoute] int year)
+        {
+            if (!ModelState.IsValid)
+            {
+                return BadRequest(ModelState);
+            }
+
+            // Load from the DB the IndicatorGroups with its Indicators, Registries, Documents, and Links
+            _context.IndicatorGroups.Include(x => x.Indicators)
+                .ThenInclude(x => x.Registries).ToList();
+            _context.LinkRegistries.Include(x => x.Links).ToList();
+
+            var indicatorGroup = await _context.IndicatorGroups.SingleOrDefaultAsync(m => m.IndicatorGroupID == id);
+
+            // If the specified indicator group doesn't exist, show NotFound
+            if (indicatorGroup == null)
+            {
+                return NotFound();
+            }
+
+            // List of the results of every indicator of the group
+            List<double> list = new List<double>();
+
+            // Calculate every indicator of the group
+            foreach (Indicator indicator in indicatorGroup.Indicators)
+            {
+                indicator.Type = indicator.Type; // Assign the IndicatorCalculator according to the Indicator's Type
+                list.Add(indicator.IndicatorCalculator.Calculate(indicator.Registries, year));
+            }
+
+            // Return the list with the results
+            return Ok(list);
+        }
+
+        // GET: api/IndicatorGroups/Calculate/1/2018/0 (group= 1, year= 2018, month= January)
+        [Route("Calculate/{id:int}/{year:int}/{month:int}")]
+        public async Task<IActionResult> CalculateIndicators([FromRoute] int id, [FromRoute] int year, [FromRoute] int month)
+        {
+            if (!ModelState.IsValid)
+            {
+                return BadRequest(ModelState);
+            }
+
+            // Load from the DB the IndicatorGroups with its Indicators, Registries, Documents, and Links
+            _context.IndicatorGroups.Include(x => x.Indicators)
+                .ThenInclude(x => x.Registries).ToList();
+            _context.LinkRegistries.Include(x => x.Links).ToList();
+
+            var indicatorGroup = await _context.IndicatorGroups.SingleOrDefaultAsync(m => m.IndicatorGroupID == id);
+
+            // If the specified indicator group doesn't exist, show NotFound
+            if (indicatorGroup == null)
+            {
+                return NotFound();
+            }
+
+            // List of the results of every indicator of the group
+            List<double> list = new List<double>();
+
+            // Calculate every indicator of the group
+            foreach (Indicator indicator in indicatorGroup.Indicators)
+            {
+                indicator.Type = indicator.Type; // Assign the IndicatorCalculator according to the Indicator's Type
+                list.Add(indicator.IndicatorCalculator.Calculate(indicator.Registries, year, month + 1)); // The month in Angular starts in 0 and in C# starts in 1
+            }
+
+            // Return the list with the results
+            return Ok(list);
+        }
+
         private bool IndicatorGroupExists(long id)
         {
             return _context.IndicatorGroups.Any(e => e.IndicatorGroupID == id);

--- a/Controllers/IndicatorsController.cs
+++ b/Controllers/IndicatorsController.cs
@@ -127,6 +127,44 @@ namespace think_agro_metrics.Controllers
             return Ok(list);
         }
 
+        // GET: api/Indicators/Calculate/2018/1
+        [Route("Calculate/{year:int}/{month:int}")]
+        public async Task<IActionResult> CalculateIndicators([FromRoute] int year, [FromRoute] int month)
+        {
+            if (!ModelState.IsValid)
+            {
+                return BadRequest(ModelState);
+            }
+
+            // Load from the DB the Indicators with its Registries, Documents, and Links
+            _context.Indicators.Include(x => x.Registries)
+                .ThenInclude(x => x.Documents).ToList();
+            _context.LinkRegistries.Include(x => x.Links).ToList();
+
+            // Obtain the Indicators
+            List<Indicator> indicators = new List<Indicator>();
+            await _context.Indicators.ForEachAsync(x => indicators.Add(x));
+
+            // If the indicators list is empty, show NotFound
+            if (!indicators.Any())
+            {
+                return NotFound();
+            }
+
+            // List of the results of every indicator
+            List<double> list = new List<double>();
+
+            // Calculate every indicator
+            foreach (Indicator indicator in indicators) {
+                indicator.Type = indicator.Type; // Assign the IndicatorCalculator according to the Indicator's Type
+                list.Add(indicator.IndicatorCalculator.Calculate(indicator.Registries, year, month+1)); // The month in Angular starts in 0 and in C# starts in 1
+            }
+            
+            // Return the list with the results
+            return Ok(list);
+        }
+
+
         // PUT: api/Indicators/5
         [HttpPut("{id}")]
         public async Task<IActionResult> PutIndicator([FromRoute] long id, [FromBody] Indicator indicator)

--- a/Controllers/IndicatorsController.cs
+++ b/Controllers/IndicatorsController.cs
@@ -63,8 +63,7 @@ namespace think_agro_metrics.Controllers
             }
 
             // Load from the DB the Indicators with its Registries, Documents, and Links
-            _context.Indicators.Include(x => x.Registries)
-                .ThenInclude(x => x.Documents).ToList();
+            _context.Indicators.Include(x => x.Registries).ToList();
             _context.LinkRegistries.Include(x => x.Links).ToList();
 
             // Obtain the Indicators
@@ -100,8 +99,7 @@ namespace think_agro_metrics.Controllers
             }
 
             // Load from the DB the Indicators with its Registries, Documents, and Links
-            _context.Indicators.Include(x => x.Registries)
-                .ThenInclude(x => x.Documents).ToList();
+            _context.Indicators.Include(x => x.Registries).ToList();
             _context.LinkRegistries.Include(x => x.Links).ToList();
 
             // Obtain the Indicators
@@ -137,8 +135,7 @@ namespace think_agro_metrics.Controllers
             }
 
             // Load from the DB the Indicators with its Registries, Documents, and Links
-            _context.Indicators.Include(x => x.Registries)
-                .ThenInclude(x => x.Documents).ToList();
+            _context.Indicators.Include(x => x.Registries).ToList();
             _context.LinkRegistries.Include(x => x.Links).ToList();
 
             // Obtain the Indicators

--- a/Models/DefaultIndicatorCalculator.cs
+++ b/Models/DefaultIndicatorCalculator.cs
@@ -22,5 +22,16 @@ namespace think_agro_metrics.Models
             }
             return counter;
         }
+
+        public double Calculate(ICollection<Registry> registries, int year, int month)
+        {   
+            int counter = 0;
+            foreach (Registry registry in registries) {
+                if(registry.Date.Year == year && registry.Date.Month == month){
+                    counter++;
+                }
+            }
+            return counter;
+        }
     }
 }

--- a/Models/IIndicatorCalculator.cs
+++ b/Models/IIndicatorCalculator.cs
@@ -9,5 +9,6 @@ namespace think_agro_metrics.Models
     {
         double Calculate(ICollection<Registry> registries);
         double Calculate(ICollection<Registry> registries, int year);
+        double Calculate(ICollection<Registry> registries, int year, int month);
     }
 }

--- a/Models/PercentIndicatorCalculator.cs
+++ b/Models/PercentIndicatorCalculator.cs
@@ -48,7 +48,7 @@ namespace think_agro_metrics.Models
             double sum = 0;
             double quantity = 0;
             foreach (Registry registry in registries) {
-                if(registry.Date.Year == year && registry.Date.Month) {
+                if(registry.Date.Year == year && registry.Date.Month == month) {
                     sum += (registry as QuantityRegistry).Quantity;
                     quantity++;
                 }

--- a/Models/PercentIndicatorCalculator.cs
+++ b/Models/PercentIndicatorCalculator.cs
@@ -11,18 +11,14 @@ namespace think_agro_metrics.Models
         {
             double sum = 0;
             double quantity = 0;
-            foreach (Registry registry in registries) {
-                if(registry.GetType() == typeof(PercentRegistry))
-                {
-                    sum += (registry as PercentRegistry).Percent;
-                    quantity++;
-                }
+            foreach (Registry registry in registries) {               
+                sum += (registry as PercentRegistry).Percent;
+                quantity++;                
             }
-            if(quantity > 0){
+            if(quantity > 0) {
                 return sum / quantity;
             }
-            else
-            {
+            else {
                 return 0;
             }
         }
@@ -32,17 +28,15 @@ namespace think_agro_metrics.Models
             double sum = 0;
             double quantity = 0;
             foreach (Registry registry in registries) {
-                if(registry.Date.Year == year && registry.GetType() == typeof(PercentRegistry))
-                {
+                if(registry.Date.Year == year) {
                     sum += (registry as PercentRegistry).Percent;
                     quantity++;
                 }
             }
-            if(quantity > 0){
+            if(quantity > 0) {
                 return sum / quantity;
             }
-            else
-            {
+            else {
                 return 0;
             }
         }
@@ -53,15 +47,14 @@ namespace think_agro_metrics.Models
             double quantity = 0;
             foreach (Registry registry in registries) {
                 if(registry.Date.Year == year && registry.Date.Month == month) {
-                    sum += (registry as QuantityRegistry).Quantity;
+                    sum += (registry as PercentRegistry).Percent;
                     quantity++;
                 }
             }
-            if(quantity > 0){
+            if(quantity > 0) {
                 return sum / quantity;
             }
-            else
-            {
+            else {
                 return 0;
             }
         }

--- a/Models/PercentIndicatorCalculator.cs
+++ b/Models/PercentIndicatorCalculator.cs
@@ -42,5 +42,24 @@ namespace think_agro_metrics.Models
                 return 0;
             }
         }
+
+        public double Calculate(ICollection<Registry> registries, int year, int month)
+        {
+            double sum = 0;
+            double quantity = 0;
+            foreach (Registry registry in registries) {
+                if(registry.Date.Year == year && registry.Date.Month) {
+                    sum += (registry as QuantityRegistry).Quantity;
+                    quantity++;
+                }
+            }
+            if(quantity > 0){
+                return sum / quantity;
+            }
+            else
+            {
+                return 0;
+            }
+        }
     }
 }

--- a/Models/QuantityIndicatorCalculator.cs
+++ b/Models/QuantityIndicatorCalculator.cs
@@ -31,7 +31,7 @@ namespace think_agro_metrics.Models
         {
             int sum = 0;
             foreach (Registry registry in registries) {
-                if(registry.Date.Year == year && registry.Date.Month == Month) {
+                if(registry.Date.Year == year && registry.Date.Month == month) {
                     sum += (registry as QuantityRegistry).Quantity;
                 }
             }

--- a/Models/QuantityIndicatorCalculator.cs
+++ b/Models/QuantityIndicatorCalculator.cs
@@ -26,5 +26,16 @@ namespace think_agro_metrics.Models
             }
             return sum;
         }
+
+        public double Calculate(ICollection<Registry> registries,int year, int month)
+        {
+            int sum = 0;
+            foreach (Registry registry in registries) {
+                if(registry.Date.Year == year && registry.Date.Month == Month) {
+                    sum += (registry as QuantityRegistry).Quantity;
+                }
+            }
+            return sum;
+        }
     }
 }


### PR DESCRIPTION
Added a second dropdown in the view of the indicator of an indicator group, that allows the selection of the month, to do the calculus for its registries of that month of a specified year.
Branched from `Feature/CalculateYear`.
**No changes in the DB (compared with the branch `Feature/CalculateYear`).**

## Added:
- Added method to calculate the indicator by month in the models and controller (.NET)
- Added `ngx-bootstrap` for the dropdowns (changes in `package.json`, `app.module.ts`, `indicator-display.component.html`).
- Added the Calculate methods in `IndicatorGroupsController.cs` (now the calculation is done only for the indicator group, not for every indicator like before).
- Added the respective Calculate methods in `indicator-group.service.ts`.
- Added a second dropdown to allow the filter by month in `indicator-display.component.html`.

## Modified:
- Modified `indicator.display.component.ts` to allow the calculation according to the filters (by year and month) using best practices.

## Kept:
- Kept the Calculate methods in `indicator.service.ts`.
- Kept and fixed (the documents aren't needed to do the calculation) the Calculate methods in `Indicator Controller.cs` in case that it is necessary for the future.