### PR TITLE
feat(FilterRegistriesByYear): completed

### DIFF
--- a/ClientApp/src/app/components/indicator-detail/indicator-detail.component.html
+++ b/ClientApp/src/app/components/indicator-detail/indicator-detail.component.html
@@ -20,80 +20,98 @@
   <h1>    {{ indicator.name }}</h1>
   <!--h2>Tipo: {{ indicator.type }}</h2-->
   <!--<div *ngIf="indicator.type == -1">El tipo es default...</div>-->
-  
 
-  <div class="heading-block" *ngIf="registriesCount != 0; else noRegistries">
-    <h2>Detalle de Registros</h2>
-  </div>
-
-  <div class="panel panel-default" *ngFor="let registry of indicator.registries">
-    <!-- Default panel contents -->
-    <div class="panel-heading">
-      {{registry.name}}
-      <div class="pull-right">
-        <button href="#" class="btn btn-success btn-xs" (click)="openModalEditRegistry(editRegistry,registry)"> <span class="glyphicon glyphicon-pencil">  </span>  </button>
-        <button href="#" class="btn btn-danger btn-xs" (click)="deleteRegistry(registry)"> <span class="glyphicon glyphicon-trash"> </span> </button>
+  <!--Dropdown Filters-->
+  <div class="row">
+    <!--Dropdown Year Filter-->
+    <div class="col-md-6">
+      Seleccione el año a mostrar:
+      <br>
+      <div class="btn-group" dropdown>
+        <button id="button-basic" dropdownToggle type="button" class="btn btn-primary dropdown-toggle" aria-controls="dropdown-basic">
+          {{ selectionYear }} <span class="caret"></span>
+        </button>
+        <ul id="dropdown-basic" *dropdownMenu class="dropdown-menu"
+            role="menu" aria-labelledby="button-basic">
+          <li><a class="dropdown-item" (click)="selectRegistriesYear(allYears)">Todos los años</a></li>
+          <li *ngFor="let year of years"><a class="dropdown-item" (click)="selectRegistriesYear(year)">Año {{ year }}</a></li>
+        </ul>
       </div>
     </div>
-    <div class="panel-body">
+  </div>
+
+    <div class="heading-block" *ngIf="registriesCount != 0; else noRegistries">
+      <h2>Detalle de Registros</h2>
+    </div>
+
+    <div class="panel panel-default" *ngFor="let registry of indicator.registries">
+      <!-- Default panel contents -->
+      <div class="panel-heading">
+        {{registry.name}}
+        <div class="pull-right">
+          <button href="#" class="btn btn-success btn-xs" (click)="openModalEditRegistry(editRegistry,registry)"> <span class="glyphicon glyphicon-pencil">  </span>  </button>
+          <button href="#" class="btn btn-danger btn-xs" (click)="deleteRegistry(registry)"> <span class="glyphicon glyphicon-trash"> </span> </button>
+        </div>
+      </div>
+      <div class="panel-body">
         <div class="container">
-            <h6>Datos registro</h6>
+          <h6>Datos registro</h6>
         </div>
-      <!-- Table -->
-      <table class="table">
-        <tr><td><b>Fecha ingreso de registro</b></td><td></td><td></td><td>{{registry.date | date:'dd-MM-yyyy'}}</td></tr>
-        <tr *ngIf="indicator.type == 1"><td><b>Cantidad</b></td><td></td><td></td><td>{{registry.quantity}}</td></tr>
-        <tr *ngIf="indicator.type == 2"><td><b>Porcentaje</b></td><td></td><td></td><td>{{registry.percent}}%</td></tr>
-      </table>
-      <div class="container">
+        <!-- Table -->
+        <table class="table">
+          <tr><td><b>Fecha ingreso de registro</b></td><td></td><td></td><td>{{registry.date | date:'dd-MM-yyyy'}}</td></tr>
+          <tr *ngIf="indicator.type == 1"><td><b>Cantidad</b></td><td></td><td></td><td>{{registry.quantity}}</td></tr>
+          <tr *ngIf="indicator.type == 2"><td><b>Porcentaje</b></td><td></td><td></td><td>{{registry.percent}}%</td></tr>
+        </table>
+        <div class="container">
           <h6>Documentos de respaldo</h6>
+        </div>
+        <table class="table">
+          <tr *ngFor="let document of registry.documents">
+            <td><b>{{document.name}}</b></td>
+            <td>{{document.date | date: 'dd-MM-yyyy'}}</td>
+            <td><a href="{{ document.link }}">Descargar</a></td>
+            <td><button class="btn btn-danger btn-xs pull-right" (click)="deleteDocument(registry,document)"> <span class="glyphicon glyphicon-trash"> </span> </button></td>
+          </tr>
+        </table>
+        <!--
+        <table class="table">
+          <thead>
+              <tr><td><b>Documentos de respaldo</b></td><td></td><td></td></tr>
+          <p *ngIf="registry.documents.length == 0"><em> No hay documentos</em></p>
+
+          </thead>
+          <tbody>
+              <tr *ngFor = "let document of registry.documents">
+                  <td><b>{{document.name}}</b></td>
+                  <td><a href={{document.link}}>Descargar</a></td>
+                  <td><button href="#" class="btn btn-danger btn-xs pull-right" (click)="deleteDocument(document)" > <span class="glyphicon glyphicon-trash"> </span> </button></td>
+                </tr>
+          </tbody>
+        </table>
+        -->
       </div>
-      <table class="table">
-        <tr *ngFor = "let document of registry.documents">
-          <td><b>{{document.name}}</b></td>
-          <td>{{document.date | date: 'dd-MM-yyyy'}}</td>
-          <td><a href="{{ document.link }}">Descargar</a></td>
-          <td><button class="btn btn-danger btn-xs pull-right" (click)="deleteDocument(registry,document)" > <span class="glyphicon glyphicon-trash"> </span> </button></td>
-        </tr>
-      </table>
-      <!--
-      <table class="table">
-        <thead>
-            <tr><td><b>Documentos de respaldo</b></td><td></td><td></td></tr>
-        <p *ngIf="registry.documents.length == 0"><em> No hay documentos</em></p>
-            
-        </thead>
-        <tbody>
-            <tr *ngFor = "let document of registry.documents">
-                <td><b>{{document.name}}</b></td>
-                <td><a href={{document.link}}>Descargar</a></td>
-                <td><button href="#" class="btn btn-danger btn-xs pull-right" (click)="deleteDocument(document)" > <span class="glyphicon glyphicon-trash"> </span> </button></td>
-              </tr>
-        </tbody>
-      </table>
-      -->
     </div>
-  </div>
 
 
 
-  <button type="button" class="btn btn-primary" (click)="openModal(template)">Añadir registro</button>
+    <button type="button" class="btn btn-primary" (click)="openModal(template)">Añadir registro</button>
     <ng-template #template>
-        <div class="modal-header">
-            <h4 class="modal-title pull-left">Ingrese un Nuevo Registro</h4>
-            <button type="button" class="close pull-right" aria-label="Close" (click)="modalRef.hide()">
-                <span aria-hidden="true">&times;</span>
-            </button>
-        </div>
-        <div class="modal-body">
-            <app-registry-form [indicator]="indicator" [idIndicator]="idIndicator" [modalRef]="modalRef"></app-registry-form>
-        </div>
+      <div class="modal-header">
+        <h4 class="modal-title pull-left">Ingrese un Nuevo Registro</h4>
+        <button type="button" class="close pull-right" aria-label="Close" (click)="modalRef.hide()">
+          <span aria-hidden="true">&times;</span>
+        </button>
+      </div>
+      <div class="modal-body">
+        <app-registry-form [indicator]="indicator" [idIndicator]="idIndicator" [modalRef]="modalRef"></app-registry-form>
+      </div>
     </ng-template>
 
     <!--Modal Edit Registry-->
     <ng-template #editRegistry>
-        <app-registry-editor [registry]="registry" [type]="type" [editModalRef]="editModalRef" #editRegistry></app-registry-editor>
+      <app-registry-editor [registry]="registry" [type]="type" [editModalRef]="editModalRef" #editRegistry></app-registry-editor>
     </ng-template>
 
-  <!--END Modal Edit Registry-->
-</div>
+    <!--END Modal Edit Registry-->
+  </div>

--- a/ClientApp/src/app/components/indicator-detail/indicator-detail.component.ts
+++ b/ClientApp/src/app/components/indicator-detail/indicator-detail.component.ts
@@ -18,6 +18,7 @@ import { BsModalRef } from 'ngx-bootstrap/modal/bs-modal-ref.service';
 // Services
 import { IndicatorService } from '../../services/indicator/indicator.service';
 import { RegistryService } from '../../services/registry/registry.service';
+import { IndicatorDisplayComponent } from '../indicator-home/indicator-display/indicator-display.component';
 
 @Component({
   selector: 'app-indicator-detail',
@@ -37,6 +38,14 @@ export class IndicatorDetailComponent implements OnInit {
   public type: number;
   public editModalRef: BsModalRef;
 
+  // For filtering by years
+  private static ALL_YEARS = 'Todos los años';
+  private static YEAR = 'Año '; // Part of the string that the DropDown has to show as selected
+  allYears: string = IndicatorDetailComponent.ALL_YEARS;
+  selectionYear: string; // Dropdow year "Año 2018"
+  selectedYear: number; // Numeric value for selectionYear
+  years: number[] = []; // List of years from 2018 to CurrentYear
+
   constructor(private service: IndicatorService,
     router: Router,
     private registryService: RegistryService,
@@ -47,7 +56,27 @@ export class IndicatorDetailComponent implements OnInit {
   }
 
   ngOnInit() {
-    this.getIndicator(this.idIndicator);
+    const currentYear = new Date().getFullYear();
+    this.getIndicator(this.idIndicator, currentYear);
+    const baseYear = 2018;
+    for (let i = 0; i <= (currentYear - baseYear); i++) {
+      this.years[i] = baseYear + i;
+    }
+    this.selectionYear = IndicatorDetailComponent.YEAR + currentYear; // Show Año 2018 on dropdown
+    this.selectedYear = currentYear; // 2018 (current year) is the selected year
+  }
+
+  selectRegistriesYear(year: any) {
+    if (year === IndicatorDetailComponent.ALL_YEARS) {
+      this.getIndicator(this.idIndicator); // Show all the registries
+      this.selectionYear = IndicatorDetailComponent.ALL_YEARS;
+      this.selectedYear = -1;
+    }
+    else {
+      this.getIndicator(this.idIndicator, year); // Show registries from the year selected
+      this.selectionYear = IndicatorDetailComponent.YEAR + year; // Change the text on the dropdown
+      this.selectedYear = year;
+    }
   }
 
   openModalEditRegistry(template: TemplateRef<any>, selectedRegistry: Registry) {
@@ -56,18 +85,26 @@ export class IndicatorDetailComponent implements OnInit {
     this.editModalRef = this.modalService.show(template);
   }
 
-  private getIndicator(indicatorId: number) {
-    this.service.getIndicator(indicatorId).subscribe(
-      data => {
-      this.indicator = data;
-      this.registriesCount = data.registries.length; },
-      err => console.error(err)
+  private getIndicator(indicatorId: number, year?: number) {
+    if (!year) {
+      this.service.getIndicator(indicatorId).subscribe(
+        data => {
+          this.indicator = data;
+          this.registriesCount = data.registries.length;
+        },
+        err => console.error(err)
       );
+    }
+    else {
+      this.service.getIndicatorYearRegistries(indicatorId, year).subscribe(
+        data => {
+          this.indicator.registries = data.registries;
+          this.registriesCount = data.registries.length;
+        },
+        err => console.error(err))
+    };
+    
   }
-
-  /*private editRegistry(registry: Registry) {
-    this.registry = { registry: registry, type: this.indicator.type };
-  }*/
 
   private deleteRegistry (registry: Registry) {
     const date: Date = new Date(registry.date);

--- a/ClientApp/src/app/services/indicator/indicator.service.ts
+++ b/ClientApp/src/app/services/indicator/indicator.service.ts
@@ -28,6 +28,10 @@ export class IndicatorService {
     return this.http.get<Indicator>(IndicatorService.INDICATORS_API + indicatorId);
   }
 
+  getIndicatorYearRegistries(indicatorId: number, year: number): Observable<Indicator> {
+    return this.http.get<Indicator>(IndicatorService.INDICATORS_API + indicatorId + '/' + year);
+  }
+
     calculateIndicators(): Observable<number[]> {
         return this.http.get<number[]>(IndicatorService.INDICATORS_API + 'Calculate');
     }

--- a/Controllers/IndicatorsController.cs
+++ b/Controllers/IndicatorsController.cs
@@ -53,6 +53,49 @@ namespace think_agro_metrics.Controllers
             return Ok(indicator);
         }
 
+        // GET: api/Indicators/5/2018
+        [HttpGet("{id:long}/{year:int}")]
+        public async Task<IActionResult> GetIndicatorRegitriesByYear([FromRoute] long id, [FromRoute] int year)
+        {
+            if(!ModelState.IsValid)
+            {
+                return BadRequest(ModelState);
+            }
+
+            // Obtain the Indicator
+            var indicator = await _context.Indicators.SingleOrDefaultAsync(i => i.IndicatorID == id);
+
+            // Fails if not found
+            if (indicator == null) 
+            {
+                return NotFound();
+            }
+
+            // Include Registries and Documents and Links
+            _context.Indicators.Include(x => x.Registries)
+                .ThenInclude(x => x.Documents).ToList();
+            _context.LinkRegistries.Include(x => x.Links).ToList();
+
+            List<Registry> registries = new List<Registry>();
+
+            // To find those who don't match the selected year
+            foreach (Registry registry in indicator.Registries)
+            {
+                if (registry.Date.Year != year)
+                {
+                    registries.Add(registry);
+                }
+            }
+
+            // Delete from the indicator returned (not in DB) the registries that we don't want to see
+            foreach(Registry registry in registries)
+            {
+                indicator.Registries.Remove(registry);
+            }
+
+            return Ok(indicator);
+        }
+
         // GET: api/Indicators/Calculate
         [Route("Calculate")]
         public async Task<IActionResult> CalculateIndicators()


### PR DESCRIPTION
Registries can now be filtered by a year using a dropdown in `indicator-detail.html`

Modified:
- `indicator-detail.component.html` to add de dropdown.
- `indicator-detail.component.ts` to add functionality to the dropdown.
- `indicator.service.ts` to allow to read the indicator from the new api-endpoint.
- `IndicatorsController.cs` to add api-endpoint that returns an indicator but only with the registries from the year selected.
