### PR TITLE
Fix/EditModalBug

### DIFF
--- a/ClientApp/src/app/components/indicator-detail/indicator-detail-registry/indicator-detail-registry.component.html
+++ b/ClientApp/src/app/components/indicator-detail/indicator-detail-registry/indicator-detail-registry.component.html
@@ -56,5 +56,5 @@
 
 <!--Modal Edit Registry-->
 <ng-template #editRegistry>
-  <app-registry-editor [registry]="registry" [registriesType]="registriesType" [editModalRef]="editModalRef" #editRegistry></app-registry-editor>
+  <app-registry-editor [registry]="registry" [registries]="registries" [registriesType]="registriesType" [editModalRef]="editModalRef" #editRegistry></app-registry-editor>
 </ng-template>

--- a/ClientApp/src/app/components/indicator-detail/registry-editor/registry-editor.component.html
+++ b/ClientApp/src/app/components/indicator-detail/registry-editor/registry-editor.component.html
@@ -8,7 +8,7 @@
   <form (ngSubmit)="editRegistry()" #registryEditForm="ngForm">
     <div class="form-group">
       <label for="name">Nombre</label>
-      <input type="text" class="form-control" id="name" required [(ngModel)]="registry.name" name="name" #name="ngModel" />
+      <input type="text" class="form-control" id="name" required [(ngModel)]="newRegistry.name" name="name" #name="ngModel" />
       <div [hidden]="name.valid || name.pristine"
             class="alert alert-danger">
         Nombre no puede estar vacio
@@ -17,7 +17,7 @@
 
     <div class="form-group">
       <label for="date">Fecha</label>
-      <input type="date" class="form-control" id="date" required [ngModel]="registry.date | date:'yyyy-MM-dd'" (ngModelChange)="registry.date = $event" name="date" #date="ngModel" />
+      <input type="date" class="form-control" id="date" required [ngModel]="newRegistry.date | date:'yyyy-MM-dd'" (ngModelChange)="newRegistry.date = $event" name="date" #date="ngModel" />
       <div [hidden]="(date.valid || date.pristine)"
             class="alert alert-danger">
         Fecha es requerida
@@ -26,7 +26,7 @@
 
     <div class="form-group" *ngIf="registriesType === 1">
       <label for="quantity">Cantidad</label>
-      <input type="text" pattern="[0-9]{1,}" class="form-control" id="quantity" required [(ngModel)]="registry.quantity" name="quantity" #quantity="ngModel" />
+      <input type="text" pattern="[0-9]{1,}" class="form-control" id="quantity" required [(ngModel)]="newRegistry.quantity" name="quantity" #quantity="ngModel" />
       <div [hidden]="(quantity.valid || quantity.pristine)"
             class="alert alert-danger">
         Cantidad deber ser un número entero
@@ -35,31 +35,13 @@
 
     <div class="form-group" *ngIf="registriesType === 2">
       <label for="percent">Porcentaje</label>
-      <input type="text" pattern="[0-9]{1,}[\.]{0,1}[0-9]{1,}" class="form-control" id="percent" required [(ngModel)]="registry.percent" name="percent" #percent="ngModel" />
+      <input type="text" pattern="[0-9]{1,}[\.]{0,1}[0-9]{1,}" class="form-control" id="percent" required [(ngModel)]="newRegistry.percent" name="percent" #percent="ngModel" />
       <div [hidden]="(percent.valid || percent.pristine)"
             class="alert alert-danger">
         Porcentaje debe ser un número entero o decimal (punto "." es separador de decimales)
       </div>
     </div>
     
-    <!--Documents section deleted/commented because Design will do this in another way
-    <div class="heading-block">
-      <h4>Documentos</h4>
-    </div>
-    <div class="panel panel-default">
-      <table class="table">
-        <thead><tr><td>Nombre</td><td></td></tr></thead>
-        <tbody>
-          <tr *ngFor="let document of registry.registry.documents">
-            <td>{{ document.name }}</td>
-            <td>
-              <button href="#" class="btn btn-danger btn-xs" (click)="deleteDocument(document)" > <span class="glyphicon glyphicon-trash"> </span> </button>
-            </td>
-          </tr>
-        </tbody>
-      </table>
-    </div>
-    -->
     <div class="modal-footer"> <!--modal-footer needed, in other case, the button will be outside the modal-->
       <button type="submit" class="btn btn-success pull-right" [disabled]="!registryEditForm.form.valid">Editar</button>
     </div>

--- a/ClientApp/src/app/components/indicator-detail/registry-editor/registry-editor.component.ts
+++ b/ClientApp/src/app/components/indicator-detail/registry-editor/registry-editor.component.ts
@@ -6,6 +6,7 @@ import { RegistryService } from '../../../services/registry/registry.service';
 import { BsModalRef } from 'ngx-bootstrap/modal';
 
 import { Document } from '../../../shared/models/document';
+import { equal, deepEqual, notDeepEqual } from 'assert';
 
 @Component({
   selector: 'app-registry-editor',
@@ -15,7 +16,11 @@ import { Document } from '../../../shared/models/document';
 export class RegistryEditorComponent implements OnInit {
 
   @Input()
+  public registries: Registry[]; // To automatically update the registries; this.registry = this.newRegistry didn't work
+
+  @Input()
   public registry: Registry;
+  public newRegistry: Registry;
 
   @Input()
   public registriesType: number;
@@ -27,10 +32,23 @@ export class RegistryEditorComponent implements OnInit {
 
   constructor(private service: RegistryService) {  }
 
-  ngOnInit() {  }
+  ngOnInit() {
+    this.newRegistry = JSON.parse(JSON.stringify(this.registry)); // To create a clone of the selected registry (this.registry)
+  }
 
   editRegistry() {
-    this.service.editRegistry(this.registry, this.registriesType).subscribe();
+    try {
+      notDeepEqual(this.registry, this.newRegistry); // If registry and newRegistry are not equal, just close the modal
+      this.service.editRegistry(this.newRegistry, this.registriesType).subscribe();
+
+      // replacing the old registry (this.registry) with the edited registry (this.newRegistry)
+      let index = this.registries.indexOf(this.registry);
+      this.registries[index] = this.newRegistry;
+
+    }
+    catch (error) {
+
+    }
     this.editModalRef.hide();
     // this.registry = null;
     this.editModalRef = null;


### PR DESCRIPTION
Now, the modal and form works with a clone of the original Registry.
Then, iff the original and clone are different (not deep equal), the service query gets executed.

Now, `registry-editor` receives the list of registries as `@Input()` just to keep the list updated.