### PR TITLE
Improves to Documents Preview Modal

### DIFF
--- a/ClientApp/src/app/app.module.ts
+++ b/ClientApp/src/app/app.module.ts
@@ -50,6 +50,7 @@ import { FileDocumentSubformComponent } from './components/registry-form/file-do
 
 import { defineLocale } from 'ngx-bootstrap/chronos';
 import { esLocale } from 'ngx-bootstrap/locale';
+import { SafeDomPipe } from './shared/safe-dom.pipe';
 defineLocale('es', esLocale);
 
 @NgModule({
@@ -79,7 +80,8 @@ defineLocale('es', esLocale);
     IndicatorFormComponent,
     AddDocumentFormComponent,
     LinkDocumentSubformComponent,
-    FileDocumentSubformComponent
+    FileDocumentSubformComponent,
+    SafeDomPipe,
   ],
   imports: [
     BsDropdownModule.forRoot(),

--- a/ClientApp/src/app/components/indicator-detail/document-preview/document-preview.component.html
+++ b/ClientApp/src/app/components/indicator-detail/document-preview/document-preview.component.html
@@ -9,7 +9,13 @@
       <pdf-viewer *ngIf="document.extension=='.pdf'" 
         src="{{'/api/Files/' + this.document.link}}">
       </pdf-viewer>
-      <div *ngIf="document.extension!='.pdf'">
+      <div *ngIf="document.extension=='.jpg' || document.extension=='.jpeg' || document.extension=='.png'">
+        <img src="{{'/api/Files/' + this.document.link}}">
+      </div>
+      <div *ngIf="document.extension!='.pdf'
+      && document.extension!='.jpg'
+      && document.extension!='.jpeg'
+      && document.extension!='.png'">
         Lo sentimos. No existe una vista previa para este archivo.
       </div>
     </div>

--- a/ClientApp/src/app/components/indicator-detail/document-preview/document-preview.component.html
+++ b/ClientApp/src/app/components/indicator-detail/document-preview/document-preview.component.html
@@ -5,7 +5,14 @@
     </button>
   </div>
   <div class="modal-body">
-    <div *ngIf="document && document.link">
+    <div *ngIf="document.extension!='.pdf'
+    && document.extension!='.jpg'
+    && document.extension!='.jpeg'
+    && document.extension!='.png'
+    && document.extension!='link'; else contentDiv">
+      Lo sentimos. No existe una vista previa para este archivo.
+    </div>
+    <ng-template #contentDiv>
       <div *ngIf="loading" class="inner-loading-wheel">
         <div class="loader-wheel"></div>
       </div>
@@ -19,12 +26,5 @@
       <iframe style="height:80vh; width:100%;" *ngIf="document.extension=='link'" 
       [src]="this.document.link | safeDom" (load)="loading=false">
       </iframe>
-      <div *ngIf="document.extension!='.pdf'
-      && document.extension!='.jpg'
-      && document.extension!='.jpeg'
-      && document.extension!='.png'
-      && document.extension!='link'">
-        Lo sentimos. No existe una vista previa para este archivo.
-      </div>
-    </div>
+    </ng-template>
   </div>

--- a/ClientApp/src/app/components/indicator-detail/document-preview/document-preview.component.html
+++ b/ClientApp/src/app/components/indicator-detail/document-preview/document-preview.component.html
@@ -12,10 +12,13 @@
       <div *ngIf="document.extension=='.jpg' || document.extension=='.jpeg' || document.extension=='.png'">
         <img src="{{'/api/Files/' + this.document.link}}">
       </div>
+      <iframe style="height:80vh; width:100%;" *ngIf="document.extension=='link'" [src]="this.document.link | safeDom">
+      </iframe>
       <div *ngIf="document.extension!='.pdf'
       && document.extension!='.jpg'
       && document.extension!='.jpeg'
-      && document.extension!='.png'">
+      && document.extension!='.png'
+      && document.extension!='link'">
         Lo sentimos. No existe una vista previa para este archivo.
       </div>
     </div>

--- a/ClientApp/src/app/components/indicator-detail/document-preview/document-preview.component.html
+++ b/ClientApp/src/app/components/indicator-detail/document-preview/document-preview.component.html
@@ -6,13 +6,18 @@
   </div>
   <div class="modal-body">
     <div *ngIf="document && document.link">
-      <pdf-viewer *ngIf="document.extension=='.pdf'" 
-        src="{{'/api/Files/' + this.document.link}}">
-      </pdf-viewer>
-      <div *ngIf="document.extension=='.jpg' || document.extension=='.jpeg' || document.extension=='.png'">
-        <img src="{{'/api/Files/' + this.document.link}}">
+      <div *ngIf="loading" class="inner-loading-wheel">
+        <div class="loader-wheel"></div>
       </div>
-      <iframe style="height:80vh; width:100%;" *ngIf="document.extension=='link'" [src]="this.document.link | safeDom">
+      <div *ngIf="document.extension=='.pdf'">
+        <pdf-viewer src="{{'/api/Files/' + this.document.link}}" (after-load-complete)="loading=false">
+        </pdf-viewer>
+      </div>
+      <div *ngIf="document.extension=='.jpg' || document.extension=='.jpeg' || document.extension=='.png'">
+        <img src="{{'/api/Files/' + this.document.link}}" (load)="loading=false">
+      </div>
+      <iframe style="height:80vh; width:100%;" *ngIf="document.extension=='link'" 
+      [src]="this.document.link | safeDom" (load)="loading=false">
       </iframe>
       <div *ngIf="document.extension!='.pdf'
       && document.extension!='.jpg'
@@ -21,8 +26,5 @@
       && document.extension!='link'">
         Lo sentimos. No existe una vista previa para este archivo.
       </div>
-    </div>
-    <div *ngIf="!document || !document.link">
-      Cargando...
     </div>
   </div>

--- a/ClientApp/src/app/components/indicator-detail/document-preview/document-preview.component.ts
+++ b/ClientApp/src/app/components/indicator-detail/document-preview/document-preview.component.ts
@@ -16,7 +16,15 @@ import { FileService } from '../../../services/file/file.service';
 export class DocumentPreviewComponent implements OnInit {
 
   pdfSource;
-  @Input() document: Document;
+  _document: Document;
+  @Input()
+  get document(): Document {
+    return this._document;
+  }
+  set document(value: Document){
+    this._document = value;
+    if (!value) this.loading = true;
+  }
   @Input() modalRef: BsModalRef;
 
   loading: boolean = true;

--- a/ClientApp/src/app/components/indicator-detail/document-preview/document-preview.component.ts
+++ b/ClientApp/src/app/components/indicator-detail/document-preview/document-preview.component.ts
@@ -19,6 +19,8 @@ export class DocumentPreviewComponent implements OnInit {
   @Input() document: Document;
   @Input() modalRef: BsModalRef;
 
+  loading: boolean = true;
+
   constructor(private http: HttpClient,
               private fileService: FileService) {
   }

--- a/ClientApp/src/app/components/indicator-detail/indicator-detail-registry/indicator-detail-registry.component.html
+++ b/ClientApp/src/app/components/indicator-detail/indicator-detail-registry/indicator-detail-registry.component.html
@@ -142,7 +142,7 @@
 
 <!-- Modal document preview -->
 <div bsModal #lgModal="bs-modal" class="modal fade" tabindex="-1"
-     role="dialog" aria-labelledby="dialog-sizes-name1">
+     role="dialog" aria-labelledby="dialog-sizes-name1" (onHidden)="document=null">
   <div class="modal-dialog modal-lg">
     <div class="modal-content">
         <app-document-preview [document]="document" [modalRef]="modalRef"></app-document-preview>

--- a/ClientApp/src/app/components/indicator-detail/indicator-detail-registry/indicator-detail-registry.component.html
+++ b/ClientApp/src/app/components/indicator-detail/indicator-detail-registry/indicator-detail-registry.component.html
@@ -44,19 +44,13 @@
                 <br /> {{document.extension}}
               </div>
               <div fxFlex="10%">
-                <button *ngIf="document.extension=='link'; else viewFileTemplate" 
-                type="button" (click)="goToLinkBlank(document.link)" class="btn btn-xs btn-primary">
+                <button type="button" class="btn btn-xs btn-primary" (click)="openModalDocumentPreview($event, lgModal, document)">
                   Ver
                 </button>
-                <ng-template #viewFileTemplate>
-                    <button type="button" class="btn btn-xs btn-primary" (click)="openModalDocumentPreview($event, lgModal, document)">
-                      Ver
-                    </button>
-                </ng-template>
               </div>
               <div fxFlex="15%">
                 <button *ngIf="document.extension=='link'; else downloadFileTemplate" 
-                type="button" (click)="goToLink(document.link)" class="btn btn-xs btn-info btn-size-text">
+                type="button" (click)="goToLinkBlank(document.link)" class="btn btn-xs btn-info btn-size-text">
                   Descargar
                 </button>
                 <ng-template #downloadFileTemplate>

--- a/ClientApp/src/app/shared/safe-dom.pipe.spec.ts
+++ b/ClientApp/src/app/shared/safe-dom.pipe.spec.ts
@@ -1,0 +1,8 @@
+import { SafeDomPipe } from './safe-dom.pipe';
+
+describe('SafeDomPipe', () => {
+  it('create an instance', () => {
+    const pipe = new SafeDomPipe();
+    expect(pipe).toBeTruthy();
+  });
+});

--- a/ClientApp/src/app/shared/safe-dom.pipe.ts
+++ b/ClientApp/src/app/shared/safe-dom.pipe.ts
@@ -1,0 +1,15 @@
+import { Pipe, PipeTransform } from '@angular/core';
+import { DomSanitizer } from "@angular/platform-browser";
+
+@Pipe({
+  name: 'safeDom'
+})
+export class SafeDomPipe implements PipeTransform {
+
+  constructor(private sanitizer: DomSanitizer) { }
+
+  transform(url: any, args?: any): any {
+    return this.sanitizer.bypassSecurityTrustResourceUrl(url);
+  }
+
+}

--- a/ClientApp/src/index.html
+++ b/ClientApp/src/index.html
@@ -63,6 +63,15 @@
   width: 100%;
   background-color: #0000008A;
 }
+.inner-loading-wheel {
+	height: 80px;
+}
+.inner-loading-wheel .loader-wheel {
+	border-left: 5px solid #666;
+}
+.inner-loading-wheel .loader-wheel::after {
+	border-left: 5px solid #666;
+}
 
   </style>
   <link href='https://fonts.googleapis.com/css?family=Open+Sans:400,400italic,600,600italic,700,700italic,300italic,300' rel="preload" as="style">


### PR DESCRIPTION
Now, there are 2 more document previews supported:
 * Images
 * Links

A safe pipe was added for dom sanitize.

The loader wheel is now available to use in inner elements, and is as preloader for previews. As background should be white, white lines are changed to #666 (color).