### PR TITLE
Fix(#88): completed

### DIFF
--- a/ClientApp/src/app/app.module.ts
+++ b/ClientApp/src/app/app.module.ts
@@ -54,6 +54,8 @@ import { FileDocumentSubformComponent } from './components/registry-form/file-do
 import { defineLocale } from 'ngx-bootstrap/chronos';
 import { esLocale } from 'ngx-bootstrap/locale';
 import { NotificationService } from './services/alerts/notification.service';
+import { PreviousRouteService } from './services/previous-route/previous-route.service';
+
 defineLocale('es', esLocale);
 
 @NgModule({
@@ -140,6 +142,7 @@ defineLocale('es', esLocale);
     FileService,
     NotificationService,
     LoaderService,
+    PreviousRouteService,
     {
       provide: HTTP_INTERCEPTORS,
       useClass: LoaderInterceptor,

--- a/ClientApp/src/app/components/navigation-buttons/navigation-buttons.component.ts
+++ b/ClientApp/src/app/components/navigation-buttons/navigation-buttons.component.ts
@@ -1,5 +1,7 @@
-import { ActivatedRoute, Router } from "@angular/router";
+import { ActivatedRoute, Router } from '@angular/router';
 import { Component, OnInit } from '@angular/core';
+
+import { PreviousRouteService } from '../../services/previous-route/previous-route.service';
 
 @Component({
   selector: 'app-navigation-buttons',
@@ -8,33 +10,24 @@ import { Component, OnInit } from '@angular/core';
 })
 export class NavigationButtonsComponent implements OnInit {
 
-  private idIndicatorGroup: number = null;
-  private idIndicator: number = null;
   private router: Router;
 
   constructor(router: Router,
-    private route: ActivatedRoute) {
-    this.idIndicatorGroup = this.route.snapshot.params.idIndicatorGroup;
-    this.idIndicator = this.route.snapshot.params.idIndicator;
+    private route: ActivatedRoute,
+    private service: PreviousRouteService) {
     this.router = router;
   }
 
   ngOnInit() {
   }
 
-  goBack()
-  {
-    if (this.idIndicatorGroup != null && this.idIndicator != null) {  // If is an indicator-detail view, go back to indicatorGroup view
-      this.router.navigateByUrl("indicatorGroup/" + this.idIndicatorGroup);
-    }
-    else {
-      this.router.navigateByUrl("/home"); // Otherwise is an indicator-display view, to back home
-    }
+  goBack() {
+    const previousRoute: string = this.service.getPreviousUrl();
+    this.router.navigateByUrl(previousRoute);
   }
 
-  goHome()
-  {
-    this.router.navigateByUrl("/home");
+  goHome() {
+    this.router.navigateByUrl('/home');
   }
 
 }

--- a/ClientApp/src/app/services/previous-route/previous-route.service.spec.ts
+++ b/ClientApp/src/app/services/previous-route/previous-route.service.spec.ts
@@ -1,0 +1,15 @@
+import { TestBed, inject } from '@angular/core/testing';
+
+import { PreviousRouteService } from './previous-route.service';
+
+describe('PreviousRouteServiceService', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [PreviousRouteService]
+    });
+  });
+
+  it('should be created', inject([PreviousRouteService], (service: PreviousRouteService) => {
+    expect(service).toBeTruthy();
+  }));
+});

--- a/ClientApp/src/app/services/previous-route/previous-route.service.ts
+++ b/ClientApp/src/app/services/previous-route/previous-route.service.ts
@@ -1,0 +1,27 @@
+import { Injectable } from '@angular/core';
+import {Router, NavigationEnd } from '@angular/router';
+
+@Injectable()
+export class PreviousRouteService {
+
+  private previousUrl: string;
+  private currentUrl: string;
+
+  constructor(private router: Router) {
+    this.currentUrl = this.router.url;
+    this.previousUrl = '/home'; // First page load
+    router.events.subscribe( event => {
+      if (event instanceof NavigationEnd) {
+        if (this.currentUrl !== event.url) {
+          this.previousUrl = this.currentUrl;
+        this.currentUrl = event.url;
+        }
+      }
+    });
+   }
+
+   public getPreviousUrl(): string {
+    return this.previousUrl;
+   }
+
+}


### PR DESCRIPTION
Adds a service (`PreviousRouteService`) that listen the changes on routes and return the previous route when it gets asked (`getPreviousRoute()`). If there isn't a previous route (when the page gets loaded for first time) it returns `/home`.
Is used on goBack functionality.

Fix/#88 