### PR TITLE
Change to Token's Role creation

### DIFF
--- a/Controllers/AuthorizationController.cs
+++ b/Controllers/AuthorizationController.cs
@@ -121,7 +121,8 @@ namespace think_agro_metrics.Controllers
             }
             foreach (var userRole in userRoles)
             {
-                claims.Add(new Claim(ClaimTypes.Role, string.Concat(userRole.Resultado.Nombre.Select((x,i) => i > 0 && (char.IsUpper(x) || char.IsWhiteSpace(x)) ? "_" + x.ToString().ToLower() : x.ToString().ToLower()))));
+                // Used to return "administrad_ _indicadores" for "Administrador Indicadores", now it return "administrador_indicadores".
+                claims.Add(new Claim(ClaimTypes.Role, string.Concat(userRole.Resultado.Nombre.Select((x,i) => i > 0 && char.IsWhiteSpace(x) ? "_" : x.ToString().ToLower()))));
                 claims.Add(new Claim("role_ids", userRole.Resultado.Id));
                 // came with this idea while listening https://www.youtube.com/watch?v=7PYe57MwxPI while drunk
                 using (StreamReader r = new StreamReader("Data/permissions.json")) 

--- a/Controllers/FilesController.cs
+++ b/Controllers/FilesController.cs
@@ -52,7 +52,7 @@ namespace ThinkAgroMetrics.Controllers
 
         // PUT: api/Files/5
         [HttpPut("{id}")]
-        [Authorize(Roles = "administrador")]
+        [Authorize(Roles = "administrador_indicadores")]
         public async Task<IActionResult> PutDocument([FromRoute] long id, [FromBody] Document document)
         {
             if (!ModelState.IsValid)

--- a/Controllers/FilesController.cs
+++ b/Controllers/FilesController.cs
@@ -29,7 +29,7 @@ namespace ThinkAgroMetrics.Controllers
 
         // GET: api/Files/ASDKFJ"#L$"L#$J!#"#$JLSDG
         [HttpGet("{link}")]
-        [Authorize(Roles = "administrador,gestor_contenido")]
+        [Authorize(Roles = "administrador_indicadores,gestor_contenido")]
         public IActionResult Download([FromRoute] string link) 
         {
             string folderName = "Repository";

--- a/Controllers/IndicatorGroupsController.cs
+++ b/Controllers/IndicatorGroupsController.cs
@@ -25,7 +25,7 @@ namespace think_agro_metrics.Controllers
 
         // GET: api/IndicatorGroups
         [HttpGet]
-        [Authorize(Roles = "administrador,gestor_contenido")]
+        [Authorize(Roles = "administrador_indicadores,gestor_contenido")]
         public async Task<IActionResult> GetIndicatorGroups()
         {
             var indicatorGroups = await _context.IndicatorGroups
@@ -52,7 +52,7 @@ namespace think_agro_metrics.Controllers
 
         // GET: api/IndicatorGroups/5
         [HttpGet("{id}")]
-        [Authorize(Roles = "administrador,gestor_contenido")]
+        [Authorize(Roles = "administrador_indicadores,gestor_contenido")]
         public async Task<IActionResult> GetIndicatorGroup([FromRoute] long id)
         {
             if (!ModelState.IsValid)
@@ -76,7 +76,7 @@ namespace think_agro_metrics.Controllers
 
         // GET: api/IndicatorsGroups/Name/5
         [HttpGet("Name/{id}")]
-        [Authorize(Roles = "administrador,gestor_contenido")]
+        [Authorize(Roles = "administrador_indicadores,gestor_contenido")]
         public async Task<IActionResult> GetIndicatorGroupName([FromRoute] long id)
         {
             if (!ModelState.IsValid)
@@ -180,7 +180,7 @@ namespace think_agro_metrics.Controllers
 
         // GET: api/IndicatorGroups/Calculate/1 (group= 1)
         [Route("Calculate/{id:int}")]
-        [Authorize(Roles = "administrador,gestor_contenido")]
+        [Authorize(Roles = "administrador_indicadores,gestor_contenido")]
         public async Task<IActionResult> CalculateIndicators([FromRoute] int id)
         {
             if (!ModelState.IsValid)
@@ -217,7 +217,7 @@ namespace think_agro_metrics.Controllers
 
         // GET: api/IndicatorGroups/Calculate/1/2018 (group= 1, year= 2018)
         [Route("Calculate/{id:int}/{year:int}")]
-        [Authorize(Roles = "administrador,gestor_contenido")]
+        [Authorize(Roles = "administrador_indicadores,gestor_contenido")]
         public async Task<IActionResult> CalculateIndicators([FromRoute] int id, [FromRoute] int year)
         {
             if (!ModelState.IsValid)
@@ -254,7 +254,7 @@ namespace think_agro_metrics.Controllers
 
         // GET: api/IndicatorGroups/Calculate/1/2018/0 (group= 1, year= 2018, month= January)
         [Route("Calculate/{id:int}/{year:int}/{month:int}")]
-        [Authorize(Roles = "administrador,gestor_contenido")]
+        [Authorize(Roles = "administrador_indicadores,gestor_contenido")]
         public async Task<IActionResult> CalculateIndicators([FromRoute] int id, [FromRoute] int year, [FromRoute] int month)
         {
             if (!ModelState.IsValid)
@@ -294,7 +294,7 @@ namespace think_agro_metrics.Controllers
 
         // GET: api/IndicatorGroups/Goals/1 (group= 1)
         [Route("Goals/{id:long}")]
-        [Authorize(Roles = "administrador,gestor_contenido")]
+        [Authorize(Roles = "administrador_indicadores,gestor_contenido")]
         public async Task<IActionResult> GetGoalsIndicators([FromRoute] long id)
         {
             if (!ModelState.IsValid)
@@ -335,7 +335,7 @@ namespace think_agro_metrics.Controllers
 
         // GET: api/IndicatorGroups/Goals/1/2018 (group = 1, year = 2018)
         [Route("Goals/{id:long}/{year:int}")]
-        [Authorize(Roles = "administrador,gestor_contenido")]
+        [Authorize(Roles = "administrador_indicadores,gestor_contenido")]
         public async Task<IActionResult> GetGoalsIndicators([FromRoute] int id, [FromRoute] int year)
         {
             if (!ModelState.IsValid)
@@ -374,7 +374,7 @@ namespace think_agro_metrics.Controllers
 
         // GET: api/IndicatorGroups/Goals/1/2018/0 (group = 1, year = 2018, month = January)
         [Route("Goals/{id:long}/{year:int}/{month:int}")]
-        [Authorize(Roles = "administrador,gestor_contenido")]
+        [Authorize(Roles = "administrador_indicadores,gestor_contenido")]
         public async Task<IActionResult> GetGoalsIndicators([FromRoute] int id, [FromRoute] int year, [FromRoute] int month)
         {
             if (!ModelState.IsValid)

--- a/Controllers/IndicatorGroupsController.cs
+++ b/Controllers/IndicatorGroupsController.cs
@@ -96,7 +96,7 @@ namespace think_agro_metrics.Controllers
 
         // PUT: api/IndicatorGroups/5
         [HttpPut("{id}")]
-        [Authorize(Roles = "administrador")]
+        [Authorize(Roles = "administrador_indicadores")]
         public async Task<IActionResult> PutIndicatorGroup([FromRoute] long id, [FromBody] IndicatorGroup indicatorGroup)
         {
             if (!ModelState.IsValid)
@@ -132,7 +132,7 @@ namespace think_agro_metrics.Controllers
 
         // POST: api/IndicatorGroups
         [HttpPost]
-        [Authorize(Roles = "administrador")]
+        [Authorize(Roles = "administrador_indicadores")]
         public async Task<IActionResult> PostIndicatorGroup([FromBody] IndicatorGroup indicatorGroup)
         {
             if (!ModelState.IsValid)
@@ -158,7 +158,7 @@ namespace think_agro_metrics.Controllers
 
         // DELETE: api/IndicatorGroups/5
         [HttpDelete("{id}")]
-        [Authorize(Roles = "administrador")]
+        [Authorize(Roles = "administrador_indicadores")]
         public async Task<IActionResult> DeleteIndicatorGroup([FromRoute] long id)
         {
             if (!ModelState.IsValid)

--- a/Controllers/IndicatorsController.cs
+++ b/Controllers/IndicatorsController.cs
@@ -407,7 +407,7 @@ namespace think_agro_metrics.Controllers
 
         // PUT: api/Indicators/5
         [HttpPut("{id}")]
-        [Authorize(Roles = "administrador")]
+        [Authorize(Roles = "administrador_indicadores")]
         public async Task<IActionResult> PutIndicator([FromRoute] long id, [FromBody] Indicator indicator)
         {
             if (!ModelState.IsValid)
@@ -443,7 +443,7 @@ namespace think_agro_metrics.Controllers
 
         // POST: api/Indicators
         [HttpPost]
-        [Authorize(Roles = "administrador")]
+        [Authorize(Roles = "administrador_indicadores")]
         public async Task<IActionResult> PostIndicator([FromBody] Indicator indicator)
         {
             if (!ModelState.IsValid)
@@ -469,7 +469,7 @@ namespace think_agro_metrics.Controllers
 
         // DELETE: api/Indicators/5
         [HttpDelete("{id}")]
-        [Authorize(Roles = "administrador")]
+        [Authorize(Roles = "administrador_indicadores")]
         public async Task<IActionResult> DeleteIndicator([FromRoute] long id)
         {
             if (!ModelState.IsValid)
@@ -496,7 +496,7 @@ namespace think_agro_metrics.Controllers
 
         // ADD REGISTRY: api/Indicators/5/AddRegistry
         [HttpPost("{indicatorId}/AddRegistry")]
-        [Authorize(Roles = "administrador")]
+        [Authorize(Roles = "administrador_indicadores")]
         public async Task<IActionResult> AddRegistry([FromRoute] long indicatorId,
             [FromBody] DefaultRegistry registry)
         {
@@ -558,7 +558,7 @@ namespace think_agro_metrics.Controllers
 
         // POST: api/Indicators/1/GoalsList
         [HttpPost("{idIndicator:long}/GoalsList")]
-        [Authorize(Roles = "administrador")]
+        [Authorize(Roles = "administrador_indicadores")]
         public async Task<IActionResult> PostGoalsList([FromRoute] long idIndicator, [FromBody] Goal[] goals)
         {
             if (!ModelState.IsValid)
@@ -574,7 +574,7 @@ namespace think_agro_metrics.Controllers
 
         // PUT: api/Indicators/Goal/7
         [HttpPut("Goal/{id:long}")]
-        [Authorize(Roles = "administrador")]
+        [Authorize(Roles = "administrador_indicadores")]
         public async Task<IActionResult> PutIndicatorGoal([FromBody] Goal goal, [FromRoute] long id)
         {
             if (!ModelState.IsValid)

--- a/Controllers/IndicatorsController.cs
+++ b/Controllers/IndicatorsController.cs
@@ -25,7 +25,7 @@ namespace think_agro_metrics.Controllers
 
         // GET: api/Indicators
         [HttpGet]
-        [Authorize(Roles = "administrador,gestor_contenido")]
+        [Authorize(Roles = "administrador_indicadores,gestor_contenido")]
         public async Task<IActionResult> GetIndicators()
         {
             var indicators = await _context.Indicators
@@ -38,7 +38,7 @@ namespace think_agro_metrics.Controllers
 
         // GET: api/Indicators/5
         [HttpGet("{id:long}")]
-        [Authorize(Roles = "administrador,gestor_contenido")]
+        [Authorize(Roles = "administrador_indicadores,gestor_contenido")]
         public async Task<IActionResult> GetIndicator([FromRoute] long id)
         {            
             if (!ModelState.IsValid)
@@ -63,7 +63,7 @@ namespace think_agro_metrics.Controllers
 
         // GET: api/Indicators/5/2018
         [HttpGet("{id:long}/{year:int}")]
-        [Authorize(Roles = "administrador,gestor_contenido")]
+        [Authorize(Roles = "administrador_indicadores,gestor_contenido")]
         public async Task<IActionResult> GetIndicatorRegitriesByYear([FromRoute] long id, [FromRoute] int year)
         {
             if(!ModelState.IsValid)
@@ -95,7 +95,7 @@ namespace think_agro_metrics.Controllers
 
         // GET: api/Indicators/5/2018/1
         [HttpGet("{id:long}/{year:int}/{month:int}")]
-        [Authorize(Roles = "administrador,gestor_contenido")]
+        [Authorize(Roles = "administrador_indicadores,gestor_contenido")]
         public async Task<IActionResult> GetIndicatorRegitriesByYearMonth([FromRoute] long id, [FromRoute] int year, [FromRoute] int month)
         {
             if(!ModelState.IsValid)
@@ -130,7 +130,7 @@ namespace think_agro_metrics.Controllers
 
         // GET: api/Indicators/Goals/1
         [HttpGet("Goals/{id:long}")]
-        [Authorize(Roles = "administrador,gestor_contenido")]
+        [Authorize(Roles = "administrador_indicadores,gestor_contenido")]
         public async Task<IActionResult> GetIndicatorGoals([FromRoute] long id)
         {
             if(!ModelState.IsValid)
@@ -163,7 +163,7 @@ namespace think_agro_metrics.Controllers
 
         // GET: api/Indicators/Goals/1/2018
         [HttpGet("Goals/{id:long}/{year:int}")]
-        [Authorize(Roles = "administrador,gestor_contenido")]
+        [Authorize(Roles = "administrador_indicadores,gestor_contenido")]
         public async Task<IActionResult> GetIndicatorGoals([FromRoute] long id, [FromRoute] int year)
         {
             if(!ModelState.IsValid)
@@ -196,7 +196,7 @@ namespace think_agro_metrics.Controllers
 
         // GET: api/Indicators/Goals/1/2018/0 (indicator 1, year 2018, month January)
         [HttpGet("Goals/{id:long}/{year:int}/{month:int}")]
-        [Authorize(Roles = "administrador,gestor_contenido")]
+        [Authorize(Roles = "administrador_indicadores,gestor_contenido")]
         public async Task<IActionResult> GetIndicatorGoals([FromRoute] long id, [FromRoute] int year, [FromRoute] int month)
         {
             if(!ModelState.IsValid)
@@ -218,7 +218,7 @@ namespace think_agro_metrics.Controllers
 
         // GET: api/Indicators/Calculate
         [Route("Calculate")]
-        [Authorize(Roles = "administrador,gestor_contenido")]
+        [Authorize(Roles = "administrador_indicadores,gestor_contenido")]
         public async Task<IActionResult> CalculateIndicators()
         {
             if (!ModelState.IsValid)
@@ -252,7 +252,7 @@ namespace think_agro_metrics.Controllers
         
         // GET: api/Indicators/Calculate/2018
         [Route("Calculate/{year:int}")]
-        [Authorize(Roles = "administrador,gestor_contenido")]
+        [Authorize(Roles = "administrador_indicadores,gestor_contenido")]
         public async Task<IActionResult> CalculateIndicators([FromRoute] int year)
         {
             if (!ModelState.IsValid)
@@ -286,7 +286,7 @@ namespace think_agro_metrics.Controllers
 
         // GET: api/Indicators/Calculate/2018/1
         [Route("Calculate/{year:int}/{month:int}")]
-        [Authorize(Roles = "administrador,gestor_contenido")]
+        [Authorize(Roles = "administrador_indicadores,gestor_contenido")]
         public async Task<IActionResult> CalculateIndicators([FromRoute] int year, [FromRoute] int month)
         {
             if (!ModelState.IsValid)
@@ -323,7 +323,7 @@ namespace think_agro_metrics.Controllers
 
         // GET: api/Indicators/Calculate/5 // Calculate Indicator with ID 5 for all years
         [Route("Calculate/{id:long}")]
-        [Authorize(Roles = "administrador,gestor_contenido")]
+        [Authorize(Roles = "administrador_indicadores,gestor_contenido")]
         public async Task<ActionResult> CalculateIndicator([FromRoute] long id)
         {
             if (!ModelState.IsValid)
@@ -350,7 +350,7 @@ namespace think_agro_metrics.Controllers
 
         // GET: api/Indicators/Calculate/5/2018 // Calculate Indicator with ID 5 for a selected year
         [Route("Calculate/{id:long}/{year:int}")]
-        [Authorize(Roles = "administrador,gestor_contenido")]
+        [Authorize(Roles = "administrador_indicadores,gestor_contenido")]
         public async Task<ActionResult> CalculateIndicatorByYear([FromRoute] long id, [FromRoute] int year)
         {
             if (!ModelState.IsValid)
@@ -377,7 +377,7 @@ namespace think_agro_metrics.Controllers
 
         // GET: api/Indicators/Calculate/5/2018/0 // Calculate Indicator with ID 5 for a selected year and selected month
         [Route("Calculate/{id:long}/{year:int}/{month:int}")]
-        [Authorize(Roles = "administrador,gestor_contenido")]
+        [Authorize(Roles = "administrador_indicadores,gestor_contenido")]
         public async Task<ActionResult> CalculateIndicatorByYearMonth([FromRoute] long id, [FromRoute] int year, [FromRoute] int month)
         {
             if (!ModelState.IsValid)
@@ -536,7 +536,7 @@ namespace think_agro_metrics.Controllers
 
         // GET: api/Indicators/1/GoalsList
         [HttpGet("{id:long}/GoalsList")]
-        [Authorize(Roles = "administrador,gestor_contenido")]
+        [Authorize(Roles = "administrador_indicadores,gestor_contenido")]
         public async Task<IActionResult> GetIndicatorGoalsList([FromRoute] long id)
         {
             if (!ModelState.IsValid)

--- a/Controllers/RegistriesController.cs
+++ b/Controllers/RegistriesController.cs
@@ -84,7 +84,7 @@ namespace think_agro_metrics.Controllers
 
         // GET: api/Registries
         [HttpGet]
-        [Authorize(Roles = "administrador,gestor_contenido")]
+        [Authorize(Roles = "administrador_indicadores,gestor_contenido")]
         public async Task<IActionResult> GetRegistries()
         {
             var registries = await _context.Registries.Include(r => r.Documents).ToListAsync();
@@ -93,7 +93,7 @@ namespace think_agro_metrics.Controllers
 
         // GET: api/Registries/5
         [HttpGet("{id}")]
-        [Authorize(Roles = "administrador,gestor_contenido")]
+        [Authorize(Roles = "administrador_indicadores,gestor_contenido")]
         public async Task<IActionResult> GetRegistry([FromRoute] long id)
         {
             if (!ModelState.IsValid)
@@ -113,7 +113,7 @@ namespace think_agro_metrics.Controllers
 
         // GET: api/Registries/External
         [HttpGet("External")]
-        [Authorize(Roles = "administrador,gestor_contenido")]
+        [Authorize(Roles = "administrador_indicadores,gestor_contenido")]
         public async Task<IActionResult> GetExternalRegistries()
         {
             var payload = this.CreateDataObject(new {

--- a/Controllers/RegistriesController.cs
+++ b/Controllers/RegistriesController.cs
@@ -181,7 +181,7 @@ namespace think_agro_metrics.Controllers
 
         // PUT: api/Registries/DefaultRegistry/5
         [HttpPut("DefaultRegistry/{id}")]
-        [Authorize(Roles = "administrador")]
+        [Authorize(Roles = "administrador_indicadores")]
         public async Task<IActionResult> PutRegistry([FromRoute] long id, [FromBody] DefaultRegistry registry)
         {   
             if (!ModelState.IsValid)
@@ -217,7 +217,7 @@ namespace think_agro_metrics.Controllers
 
         // PUT: api/Registries/QuantityRegistry/5
         [HttpPut("QuantityRegistry/{id}")]
-        [Authorize(Roles = "administrador")]
+        [Authorize(Roles = "administrador_indicadores")]
         public async Task<IActionResult> PutRegistry([FromRoute] long id, [FromBody] QuantityRegistry registry)
         {   
             if (!ModelState.IsValid)
@@ -253,7 +253,7 @@ namespace think_agro_metrics.Controllers
 
         // PUT: api/Registries/PercentRegistry/5
         [HttpPut("PercentRegistry/{id}")]
-        [Authorize(Roles = "administrador")]
+        [Authorize(Roles = "administrador_indicadores")]
         public async Task<IActionResult> PutRegistry([FromRoute] long id, [FromBody] PercentRegistry registry)
         {   
             if (!ModelState.IsValid)
@@ -289,7 +289,7 @@ namespace think_agro_metrics.Controllers
 
        // ADD REGISTRY: api/Indicators/5/AddRegistry
         [HttpPost("{indicatorId}/DefaultRegistry")]
-        [Authorize(Roles = "administrador")]
+        [Authorize(Roles = "administrador_indicadores")]
         public async Task<IActionResult> DefaultRegistry([FromRoute] long indicatorId,
             [FromBody] DefaultRegistry registry)
         {
@@ -341,7 +341,7 @@ namespace think_agro_metrics.Controllers
 
         // ADD REGISTRY: api/Indicators/5/AddRegistry
         [HttpPost("{indicatorId}/QuantityRegistry")]
-        [Authorize(Roles = "administrador")]
+        [Authorize(Roles = "administrador_indicadores")]
         public async Task<IActionResult> QuantityRegistry([FromRoute] long indicatorId,
             [FromBody] QuantityRegistry registry)
         {
@@ -388,7 +388,7 @@ namespace think_agro_metrics.Controllers
 
         // ADD REGISTRY: api/Indicators/5/AddRegistry
         [HttpPost("{indicatorId}/PercentRegistry")]
-        [Authorize(Roles = "administrador")]
+        [Authorize(Roles = "administrador_indicadores")]
         public async Task<IActionResult> PercentRegistry([FromRoute] long indicatorId,
             [FromBody] PercentRegistry registry)
         {
@@ -436,7 +436,7 @@ namespace think_agro_metrics.Controllers
 
         // DELETE: api/Registries/Documents/5
         [HttpDelete("Documents/{id}")]
-        [Authorize(Roles = "administrador")]
+        [Authorize(Roles = "administrador_indicadores")]
         public async Task<IActionResult> DeleteDocument([FromRoute] long id)
         {
             if(!ModelState.IsValid)
@@ -466,7 +466,7 @@ namespace think_agro_metrics.Controllers
 
         // DELETE: api/Registries/5
         [HttpDelete("{id}")]
-        [Authorize(Roles = "administrador")]
+        [Authorize(Roles = "administrador_indicadores")]
         public async Task<IActionResult> DeleteRegistry([FromRoute] long id)
         {
             if (!ModelState.IsValid)
@@ -503,7 +503,7 @@ namespace think_agro_metrics.Controllers
 
         // ADD LinkDocument: api/Registries/5/AddLinkDocument
         [HttpPost("{id}/AddLinkDocument")]
-        [Authorize(Roles = "administrador")]
+        [Authorize(Roles = "administrador_indicadores")]
         public async Task<IActionResult> AddLinkDocument([FromRoute] long id,
             [FromBody] Document document)
         {
@@ -554,7 +554,7 @@ namespace think_agro_metrics.Controllers
 
         // ADD FileDocument: api/Registries/5/AddFileDocument
         [HttpPost("{id}/AddFileDocument"), DisableRequestSizeLimit]
-        [Authorize(Roles = "administrador")]
+        [Authorize(Roles = "administrador_indicadores")]
         public async Task<IActionResult> AddFileDocument([FromRoute] long id)
         {
             try


### PR DESCRIPTION
This branch modifies the creation of the auth's token's role and modifies the expected role in the auth policies in the API's controllers.

Staging currently parses "Administrador Indicadores" as "administrador_ _indicadores", now it's parsed as "administrador_indicadores", such the expected role in the authorize action is "administrador_indicadores" instead of "administrador"

Update (208-08-05): @arashinishi add fixes to role auth.