### PR TITLE
Feature/Delete Indicator & IndicatorGroup (Config view)

### DIFF
--- a/ClientApp/src/app/app.module.ts
+++ b/ClientApp/src/app/app.module.ts
@@ -57,6 +57,7 @@ import { esLocale } from 'ngx-bootstrap/locale';
 import { SafeDomPipe } from './shared/safe-dom.pipe';
 import { NotificationService } from './services/alerts/notification.service';
 import { ChartComponent } from './components/indicator-detail/chart/chart.component';
+import { ConfigHomeComponent } from './components/config-home/config-home.component';
 import { PreviousRouteService } from './services/previous-route/previous-route.service';
 
 defineLocale('es', esLocale);
@@ -91,7 +92,8 @@ defineLocale('es', esLocale);
     LinkDocumentSubformComponent,
     FileDocumentSubformComponent,
     SafeDomPipe,
-    ChartComponent
+    ChartComponent,
+    ConfigHomeComponent
   ],
   imports: [
     BsDropdownModule.forRoot(),
@@ -125,6 +127,11 @@ defineLocale('es', esLocale);
       {
         path: 'home',
         component: ResultHomeComponent,
+        canActivate: [CanActivateUser]
+      },
+      {
+        path: 'config',
+        component: ConfigHomeComponent,
         canActivate: [CanActivateUser]
       },
       {

--- a/ClientApp/src/app/components/config-home/config-home.component.css
+++ b/ClientApp/src/app/components/config-home/config-home.component.css
@@ -1,9 +1,0 @@
-.btn-cancel {
-  margin-right: 5px;
-}
-
-.head-page-section{
-    margin-top: 80px !important;
-}
-
-

--- a/ClientApp/src/app/components/config-home/config-home.component.css
+++ b/ClientApp/src/app/components/config-home/config-home.component.css
@@ -1,11 +1,9 @@
+.btn-cancel {
+  margin-right: 5px;
+}
+
 .head-page-section{
     margin-top: 80px !important;
 }
 
-.btn-cancel {
-  margin-right: 10px;
-}
 
-.btn-accept {
-  margin-left: 10px;
-}

--- a/ClientApp/src/app/components/config-home/config-home.component.css
+++ b/ClientApp/src/app/components/config-home/config-home.component.css
@@ -1,3 +1,11 @@
 .head-page-section{
     margin-top: 80px !important;
-  }
+}
+
+.btn-cancel {
+  margin-right: 10px;
+}
+
+.btn-accept {
+  margin-left: 10px;
+}

--- a/ClientApp/src/app/components/config-home/config-home.component.css
+++ b/ClientApp/src/app/components/config-home/config-home.component.css
@@ -1,0 +1,3 @@
+.head-page-section{
+    margin-top: 80px !important;
+  }

--- a/ClientApp/src/app/components/config-home/config-home.component.html
+++ b/ClientApp/src/app/components/config-home/config-home.component.html
@@ -40,7 +40,7 @@
                 </div>
                 <div class="col-xs-2 col-sm-2 col-md-2 pull-right" style="margin-top: 5px;">
                   <div class="pull-right">
-                    <button class="btn btn-xs btn-danger" type="button">Eliminar</button>
+                    <button class="btn btn-xs btn-danger" type="button" (click)="deleteIndicatorGroup(ig)">Eliminar</button>
                   </div>
                 </div>
               </div>

--- a/ClientApp/src/app/components/config-home/config-home.component.html
+++ b/ClientApp/src/app/components/config-home/config-home.component.html
@@ -38,7 +38,7 @@
                     <strong>{{ ig.name }}</strong>
                   </h5>
                 </div>
-                <div class="col-xs-10 col-sm-10 col-md-10 pull-right" style="margin-top: 5px;">
+                <div class="col-xs-2 col-sm-2 col-md-2 pull-right" style="margin-top: 5px;">
                   <div class="pull-right">
                     <button class="btn btn-xs btn-danger" type="button">Eliminar</button>
                   </div>

--- a/ClientApp/src/app/components/config-home/config-home.component.html
+++ b/ClientApp/src/app/components/config-home/config-home.component.html
@@ -25,51 +25,53 @@
 
   <div class="container">
     <div style="margin-top: 10px;">
-      <tabset [justified]="true" style="margin-top: 30px;">
-        <tab>
-          <ng-template tabHeading>
-            <strong>Resultados esperados</strong>
-          </ng-template>
-          <div *ngIf="indicatorsGroups$ | async as indicatorGroups">
-            <div *ngFor="let ig of indicatorGroups" class="wide-border-promo-box promo-box pad-sec-40" style="padding: 20px; margin-bottom: 5px; margin-top: 5px;">
-              <div class="row">
-                <div class="col-xs-10 col-md-10">
-                  <h5 class="fixh5">
-                    <strong>{{ ig.name }}</strong>
-                  </h5>
+      <div class="row">
+        <div class="col-xs-12 col-sm-12 col-md-12">
+          <h2>
+            Listado de resultados esperados
+          </h2>
+        </div>
+      </div>
+      <div *ngIf="indicatorsGroups$ | async as indicatorGroups">
+        <ngb-accordion [closeOthers]="true" activeIds="static-1">
+          <ng-template ngFor let-indicatorGroup [ngForOf]="indicatorGroups" let-i="index">
+            <ngb-panel>
+              <ng-template ngbPanelTitle style="padding: 1em; border-radius: 0.5em; font-size: 14px; border: 5px solid #c4c4c4 !important; font-weight: bolder;">
+                <div class="row clickable" style="padding: 20px; margin-bottom: 5px; margin-top: 5px;">
+                    <div class="col-xs-9 col-sm-9 col-md-9">
+                      <h5 class="fixh5">
+                        {{ indicatorGroup.name }}
+                      </h5>
+                    </div>
+                    <div class="col-xs-1 col-sm-1 col-md-1" style="margin-top: 5px;">
+                        <button class="btn btn-xs btn-danger" type="button" (click)="deleteIndicatorGroup($event, indicatorGroup)">Eliminar</button>
+                    </div>
+                    <div class="col-xs-1 col-sm-1 col-md-1 pull-right">
+                      <span class="pull-right centered-vertical glyphicon glyphicon-menu-down" style="font-size: 24px; vertical-align: top; padding-top: -10px;"></span>
+                    </div>
                 </div>
-                <div class="col-xs-2 col-sm-2 col-md-2 pull-right" style="margin-top: 5px;">
-                  <div class="pull-right">
-                    <button class="btn btn-xs btn-danger" type="button" (click)="deleteIndicatorGroup(ig)">Eliminar</button>
+              </ng-template>
+              <ng-template ngbPanelContent>
+                <ng-template ngFor let-indicator [ngForOf]="indicatorGroup.indicators">
+                  <div class="row" style="margin-bottom: 5px; margin-top: 5px;">
+                    <div class="col-xs-10 col-md-10">
+                      <h5 class="fixh5">
+                        <strong>{{ indicator.name }}</strong>
+                      </h5>
+                    </div>
+                    <div class="col-xs-2 col-sm-2 col-md-2 pull-right" style="margin-top: 5px;">
+                      <div class="pull-right">
+                        <button class="btn btn-xs btn-danger" type="button" (click)="deleteIndicator($event, indicator)">Eliminar</button>
+                      </div>
+                    </div>
                   </div>
-                </div>
-              </div>
-            </div>
-          </div>
-        </tab>
-        <tab >
-          <ng-template tabHeading>
-            <strong>Indicadores</strong>
+                </ng-template>
+              </ng-template>
+            </ngb-panel>
           </ng-template>
-          <div *ngIf="indicators$ | async as indicators">
-            <div *ngFor="let i of indicators" class="wide-border-promo-box promo-box pad-sec-40" style="padding: 20px; margin-bottom: 5px; margin-top: 5px;">
-              <div class="row">
-                <div class="col-xs-10 col-md-10">
-                  <h5 class="fixh5">
-                    <strong>{{ i.name }}</strong>
-                  </h5>
-                </div>
-                <div class="col-xs-2 col-sm-2 col-md-2 pull-right" style="margin-top: 5px;">
-                  <div class="pull-right">
-                    <button class="btn btn-xs btn-danger" type="button" (click)="deleteIndicator(i)">Eliminar</button>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-        </tab>
-      </tabset>
 
+        </ngb-accordion>
+      </div>
     </div>
 
 

--- a/ClientApp/src/app/components/config-home/config-home.component.html
+++ b/ClientApp/src/app/components/config-home/config-home.component.html
@@ -43,7 +43,7 @@
                         {{ indicatorGroup.name }}
                       </h5>
                     </div>
-                    <div class="col-xs-1 col-sm-1 col-md-1" style="margin-top: 5px;">
+                    <div class="col-xs-1 col-sm-1 col-md-1">
                         <button class="btn btn-xs btn-danger" type="button" (click)="deleteIndicatorGroup($event, indicatorGroup)">Eliminar</button>
                     </div>
                     <div class="col-xs-1 col-sm-1 col-md-1 pull-right">
@@ -54,15 +54,14 @@
               <ng-template ngbPanelContent>
                 <ng-template ngFor let-indicator [ngForOf]="indicatorGroup.indicators">
                   <div class="row" style="margin-bottom: 5px; margin-top: 5px;">
-                    <div class="col-xs-10 col-md-10">
+                    <div class="col-xs-10 col-sm-10 col-md-10">
                       <h5 class="fixh5">
                         <strong>{{ indicator.name }}</strong>
                       </h5>
+
                     </div>
-                    <div class="col-xs-2 col-sm-2 col-md-2 pull-right" style="margin-top: 5px;">
-                      <div class="pull-right">
+                    <div class="col-xs-2 col-sm-2 col-md-2">
                         <button class="btn btn-xs btn-danger" type="button" (click)="deleteIndicator($event, indicator)">Eliminar</button>
-                      </div>
                     </div>
                   </div>
                 </ng-template>

--- a/ClientApp/src/app/components/config-home/config-home.component.html
+++ b/ClientApp/src/app/components/config-home/config-home.component.html
@@ -61,7 +61,7 @@
                 </div>
                 <div class="col-xs-2 col-sm-2 col-md-2 pull-right" style="margin-top: 5px;">
                   <div class="pull-right">
-                    <button class="btn btn-xs btn-danger" type="button">Eliminar</button>
+                    <button class="btn btn-xs btn-danger" type="button" (click)="deleteIndicator(i)">Eliminar</button>
                   </div>
                 </div>
               </div>

--- a/ClientApp/src/app/components/config-home/config-home.component.html
+++ b/ClientApp/src/app/components/config-home/config-home.component.html
@@ -1,6 +1,6 @@
 <!-- Head page section================================================== -->
 <section>
-<div id="head-page-section" class="l-grey-bg head-page-section">
+  <div id="head-page-section" class="l-grey-bg head-page-section">
     <div class="container">
       <app-navigation-buttons></app-navigation-buttons>
       <div class="row">
@@ -9,10 +9,72 @@
             <h1>
               Configuración
             </h1>
-          </div> <!-- end subsection-text -->
-        </div> <!-- end col-md-8 -->
-      </div> <!-- end row -->
-    </div> <!-- end container -->
+          </div>
+          <!-- end subsection-text -->
+        </div>
+        <!-- end col-md-8 -->
+      </div>
+      <!-- end row -->
+    </div>
+    <!-- end container -->
   </div>
   <!-- end head-page-section -->
+</section>
+
+<section>
+
+  <div class="container">
+    <div style="margin-top: 10px;">
+      <tabset [justified]="true" style="margin-top: 30px;">
+        <tab>
+          <ng-template tabHeading>
+            <strong>Resultados esperados</strong>
+          </ng-template>
+          <div *ngIf="indicatorsGroups$ | async as indicatorGroups">
+            <div *ngFor="let ig of indicatorGroups" class="wide-border-promo-box promo-box pad-sec-40" style="padding: 20px; margin-bottom: 5px; margin-top: 5px;">
+              <div class="row">
+                <div class="col-xs-10 col-md-10">
+                  <h5 class="fixh5">
+                    <strong>{{ ig.name }}</strong>
+                  </h5>
+                </div>
+                <div class="col-xs-10 col-sm-10 col-md-10 pull-right" style="margin-top: 5px;">
+                  <div class="pull-right">
+                    <button class="btn btn-xs btn-danger" type="button">Eliminar</button>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </tab>
+        <tab >
+          <ng-template tabHeading>
+            <strong>Indicadores</strong>
+          </ng-template>
+          <div *ngIf="indicators$ | async as indicators">
+            <div *ngFor="let i of indicators" class="wide-border-promo-box promo-box pad-sec-40" style="padding: 20px; margin-bottom: 5px; margin-top: 5px;">
+              <div class="row">
+                <div class="col-xs-10 col-md-10">
+                  <h5 class="fixh5">
+                    <strong>{{ i.name }}</strong>
+                  </h5>
+                </div>
+                <div class="col-xs-2 col-sm-2 col-md-2 pull-right" style="margin-top: 5px;">
+                  <div class="pull-right">
+                    <button class="btn btn-xs btn-danger" type="button">Eliminar</button>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </tab>
+      </tabset>
+
+    </div>
+
+
+
+  </div>
+  <!--End Container-->
+
 </section>

--- a/ClientApp/src/app/components/config-home/config-home.component.html
+++ b/ClientApp/src/app/components/config-home/config-home.component.html
@@ -1,0 +1,18 @@
+<!-- Head page section================================================== -->
+<section>
+<div id="head-page-section" class="l-grey-bg head-page-section">
+    <div class="container">
+      <app-navigation-buttons></app-navigation-buttons>
+      <div class="row">
+        <div class="col-md-12 col-sm-12">
+          <div class="head-title">
+            <h1>
+              Configuración
+            </h1>
+          </div> <!-- end subsection-text -->
+        </div> <!-- end col-md-8 -->
+      </div> <!-- end row -->
+    </div> <!-- end container -->
+  </div>
+  <!-- end head-page-section -->
+</section>

--- a/ClientApp/src/app/components/config-home/config-home.component.scss
+++ b/ClientApp/src/app/components/config-home/config-home.component.scss
@@ -1,0 +1,38 @@
+.btn-cancel {
+  margin-right: 5px;
+}
+.card {
+  margin: 1em;
+}
+
+.card-body {
+  margin: 1em;
+  padding: 1em;
+  display: none;
+  padding-top: 10px;
+}
+// This stuff matters!
+.show {
+  overflow: hidden;
+  transition: transform 2s ease-out !important; // note that we're transitioning transform, not height!
+  height: 100%;
+  transform: scaleY(1); // implicit, but good to specify explicitly
+  transform-origin: top; // keep the top of the element in the same place. this is optional.
+}
+
+.card-header {
+  padding: 1em;
+  border-radius: 0.5em;
+  font-size: 14px;
+  border: 1px solid #c4c4c4;
+  font-weight: bolder;
+
+  a {
+    color: black;
+  }
+}
+.head-page-section{
+    margin-top: 80px !important;
+}
+
+

--- a/ClientApp/src/app/components/config-home/config-home.component.scss
+++ b/ClientApp/src/app/components/config-home/config-home.component.scss
@@ -22,7 +22,7 @@
 
 .card-header {
   padding: 1em;
-  border-radius: 0.5em;
+  //border-radius: 0.5em;
   font-size: 14px;
   border: 1px solid #c4c4c4;
   font-weight: bolder;

--- a/ClientApp/src/app/components/config-home/config-home.component.spec.ts
+++ b/ClientApp/src/app/components/config-home/config-home.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ConfigHomeComponent } from './config-home.component';
+
+describe('ConfigHomeComponent', () => {
+  let component: ConfigHomeComponent;
+  let fixture: ComponentFixture<ConfigHomeComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ ConfigHomeComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(ConfigHomeComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/ClientApp/src/app/components/config-home/config-home.component.ts
+++ b/ClientApp/src/app/components/config-home/config-home.component.ts
@@ -1,0 +1,15 @@
+import { Component, OnInit } from '@angular/core';
+
+@Component({
+  selector: 'app-config-home',
+  templateUrl: './config-home.component.html',
+  styleUrls: ['./config-home.component.css']
+})
+export class ConfigHomeComponent implements OnInit {
+
+  constructor() { }
+
+  ngOnInit() {
+  }
+
+}

--- a/ClientApp/src/app/components/config-home/config-home.component.ts
+++ b/ClientApp/src/app/components/config-home/config-home.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit } from '@angular/core';
+import {Component, OnInit, ViewEncapsulation} from '@angular/core';
 import { Observable } from '../../../../node_modules/rxjs/Observable';
 
 
@@ -15,7 +15,8 @@ import swal from 'sweetalert2';
 @Component({
   selector: 'app-config-home',
   templateUrl: './config-home.component.html',
-  styleUrls: ['./config-home.component.css']
+  styleUrls: ['./config-home.component.css'],
+  encapsulation: ViewEncapsulation.None
 })
 export class ConfigHomeComponent implements OnInit {
 
@@ -53,7 +54,7 @@ export class ConfigHomeComponent implements OnInit {
       cancelButtonText: 'CANCELAR',
       buttonsStyling: false,
       reverseButtons: true,
-      confirmButtonClass: 'btn btn-sm btn-primary btn-accept',
+      confirmButtonClass: 'btn btn-sm btn-primary',
       cancelButtonClass: 'btn btn-sm btn-clean-2 btn-cancel',
       allowOutsideClick: false,
       allowEscapeKey: false

--- a/ClientApp/src/app/components/config-home/config-home.component.ts
+++ b/ClientApp/src/app/components/config-home/config-home.component.ts
@@ -9,6 +9,7 @@ import { IndicatorGroup } from '../../shared/models/indicatorGroup';
 // services
 import { IndicatorService } from '../../services/indicator/indicator.service';
 import { IndicatorGroupService } from '../../services/indicator-group/indicator-group.service';
+import { NotificationService } from '../../services/alerts/notification.service';
 
 import swal from 'sweetalert2';
 
@@ -24,7 +25,8 @@ export class ConfigHomeComponent implements OnInit {
   indicatorsGroups$: Observable<IndicatorGroup[]>;
 
   constructor(private indicatorService: IndicatorService,
-  private indicatorGroupService: IndicatorGroupService) { }
+              private indicatorGroupService: IndicatorGroupService,
+              private notificationService: NotificationService) { }
 
   ngOnInit() {
     this.indicators$ = this.indicatorService.getIndicators();
@@ -34,19 +36,55 @@ export class ConfigHomeComponent implements OnInit {
   deleteIndicator(indicator: Indicator) {
     this.confirmDeleteIndicator(indicator.name).then( result => {
       if (result.value) {
-        console.log(true);
+        this.indicatorService.deleteIndicator(indicator).subscribe(data =>{
+          this.notificationService.showToaster('Indicador eliminado', 'success');
+          this.indicators$ = this.indicatorService.getIndicators();
+        });
       } else {
-        console.log(false);
+        // Do nothing
       }
+    }, error =>{
+      this.notificationService.showToaster('Error al eliminar el registro', 'error');
     });
+  }
 
-
+  deleteIndicatorGroup(indicatorGroup: IndicatorGroup) {
+    this.confirmDeleteIndicatorGroup(indicatorGroup.name).then( result => {
+      if (result.value) {
+        this.indicatorGroupService.deleteIndicatorGroup(indicatorGroup).subscribe( data => {
+          this.notificationService.showToaster('Resultado esperado eliminado', 'success');
+          this.indicatorsGroups$ = this.indicatorGroupService.getIndicatorGroups();
+        });
+      } else {
+        // Do nothing
+      }
+    },error =>{
+        this.notificationService.showToaster('Error al eliminar el resultado esperado', 'error');
+    });
   }
 
   private confirmDeleteIndicator(name: string) {
     return swal({
       title: 'Eliminar indicador',
-      html: '<h6>¿Está seguro que desea eliminar el indicador <br>"' + name + '"?</h6><br>Esta acción no puede ser revertida y se perderán todos los registros relacionados' +
+      html: '<h6>¿Está seguro que desea eliminar el indicador <br>"' + name + '"?</h6><br>Esta acción no puede ser revertida y se perderán todos los datos relacionados' +
+      '<hr style="margin-top: 15px !important; margin-bottom: 2.5px !important;">',
+      type: 'warning',
+      showCancelButton: true,
+      confirmButtonText: 'Aceptar',
+      cancelButtonText: 'CANCELAR',
+      buttonsStyling: false,
+      reverseButtons: true,
+      confirmButtonClass: 'btn btn-sm btn-primary',
+      cancelButtonClass: 'btn btn-sm btn-clean-2 btn-cancel',
+      allowOutsideClick: false,
+      allowEscapeKey: false
+    });
+  }
+
+  private confirmDeleteIndicatorGroup(name: string) {
+    return swal({
+      title: 'Eliminar resultado esperado',
+      html: '<h6>¿Está seguro que desea eliminar el resultado<br>"' + name + '"?</h6><br>Esta acción no puede ser revertida y se perderán todos los datos relacionados' +
       '<hr style="margin-top: 15px !important; margin-bottom: 2.5px !important;">',
       type: 'warning',
       showCancelButton: true,

--- a/ClientApp/src/app/components/config-home/config-home.component.ts
+++ b/ClientApp/src/app/components/config-home/config-home.component.ts
@@ -28,7 +28,6 @@ export class ConfigHomeComponent implements OnInit {
               private notificationService: NotificationService) { }
 
   ngOnInit() {
-    this.indicators$ = this.indicatorService.getIndicators();
     this.indicatorsGroups$ = this.indicatorGroupService.getIndicatorGroups();
   }
 

--- a/ClientApp/src/app/components/config-home/config-home.component.ts
+++ b/ClientApp/src/app/components/config-home/config-home.component.ts
@@ -16,12 +16,11 @@ import swal from 'sweetalert2';
 @Component({
   selector: 'app-config-home',
   templateUrl: './config-home.component.html',
-  styleUrls: ['./config-home.component.css'],
+  styleUrls: ['./config-home.component.scss'],
   encapsulation: ViewEncapsulation.None
 })
 export class ConfigHomeComponent implements OnInit {
 
-  indicators$: Observable<Indicator[]>;
   indicatorsGroups$: Observable<IndicatorGroup[]>;
 
   constructor(private indicatorService: IndicatorService,
@@ -33,12 +32,17 @@ export class ConfigHomeComponent implements OnInit {
     this.indicatorsGroups$ = this.indicatorGroupService.getIndicatorGroups();
   }
 
-  deleteIndicator(indicator: Indicator) {
+  deleteIndicator($event: any, indicator: Indicator) {
+    if ($event) {
+      $event.stopPropagation();
+      $event.preventDefault();
+    }
+
     this.confirmDeleteIndicator(indicator.name).then( result => {
       if (result.value) {
         this.indicatorService.deleteIndicator(indicator).subscribe(data =>{
           this.notificationService.showToaster('Indicador eliminado', 'success');
-          this.indicators$ = this.indicatorService.getIndicators();
+          this.indicatorsGroups$ = this.indicatorGroupService.getIndicatorGroups();
         });
       } else {
         // Do nothing
@@ -48,7 +52,12 @@ export class ConfigHomeComponent implements OnInit {
     });
   }
 
-  deleteIndicatorGroup(indicatorGroup: IndicatorGroup) {
+  deleteIndicatorGroup($event: any, indicatorGroup: IndicatorGroup) {
+    if ($event) {
+      $event.stopPropagation();
+      $event.preventDefault();
+    }
+
     this.confirmDeleteIndicatorGroup(indicatorGroup.name).then( result => {
       if (result.value) {
         this.indicatorGroupService.deleteIndicatorGroup(indicatorGroup).subscribe( data => {

--- a/ClientApp/src/app/components/config-home/config-home.component.ts
+++ b/ClientApp/src/app/components/config-home/config-home.component.ts
@@ -1,4 +1,14 @@
 import { Component, OnInit } from '@angular/core';
+import { Observable } from '../../../../node_modules/rxjs/Observable';
+
+
+// Models
+import { Indicator } from '../../shared/models/indicator';
+import { IndicatorGroup } from '../../shared/models/indicatorGroup';
+
+// services
+import { IndicatorService } from '../../services/indicator/indicator.service';
+import { IndicatorGroupService } from '../../services/indicator-group/indicator-group.service';
 
 @Component({
   selector: 'app-config-home',
@@ -7,9 +17,15 @@ import { Component, OnInit } from '@angular/core';
 })
 export class ConfigHomeComponent implements OnInit {
 
-  constructor() { }
+  indicators$: Observable<Indicator[]>;
+  indicatorsGroups$: Observable<IndicatorGroup[]>;
+
+  constructor(private indicatorService: IndicatorService,
+  private indicatorGroupService: IndicatorGroupService) { }
 
   ngOnInit() {
+    this.indicators$ = this.indicatorService.getIndicators();
+    this.indicatorsGroups$ = this.indicatorGroupService.getIndicatorGroups();
   }
 
 }

--- a/ClientApp/src/app/components/config-home/config-home.component.ts
+++ b/ClientApp/src/app/components/config-home/config-home.component.ts
@@ -10,6 +10,8 @@ import { IndicatorGroup } from '../../shared/models/indicatorGroup';
 import { IndicatorService } from '../../services/indicator/indicator.service';
 import { IndicatorGroupService } from '../../services/indicator-group/indicator-group.service';
 
+import swal from 'sweetalert2';
+
 @Component({
   selector: 'app-config-home',
   templateUrl: './config-home.component.html',
@@ -26,6 +28,36 @@ export class ConfigHomeComponent implements OnInit {
   ngOnInit() {
     this.indicators$ = this.indicatorService.getIndicators();
     this.indicatorsGroups$ = this.indicatorGroupService.getIndicatorGroups();
+  }
+
+  deleteIndicator(indicator: Indicator) {
+    this.confirmDeleteIndicator(indicator.name).then( result => {
+      if (result.value) {
+        console.log(true);
+      } else {
+        console.log(false);
+      }
+    });
+
+
+  }
+
+  private confirmDeleteIndicator(name: string) {
+    return swal({
+      title: 'Eliminar indicador',
+      html: '<h6>¿Está seguro que desea eliminar el indicador <br>"' + name + '"?</h6><br>Esta acción no puede ser revertida y se perderán todos los registros relacionados' +
+      '<hr style="margin-top: 15px !important; margin-bottom: 2.5px !important;">',
+      type: 'warning',
+      showCancelButton: true,
+      confirmButtonText: 'Aceptar',
+      cancelButtonText: 'CANCELAR',
+      buttonsStyling: false,
+      reverseButtons: true,
+      confirmButtonClass: 'btn btn-sm btn-primary btn-accept',
+      cancelButtonClass: 'btn btn-sm btn-clean-2 btn-cancel',
+      allowOutsideClick: false,
+      allowEscapeKey: false
+    });
   }
 
 }

--- a/ClientApp/src/app/components/header/header.component.html
+++ b/ClientApp/src/app/components/header/header.component.html
@@ -10,9 +10,10 @@
     </div>
     <div class="navbar-collapse collapse">
       <ul class="nav navbar-nav navbar-right">
-          <li><a class="active" href="/">Inicio</a></li>
-          <li [class.hidden]="isLogged" ><a (click)="openModal(template)"  href="#">Iniciar Sesión</a></li>
-          <li [class.hidden]="!isLogged" ><a (click)="logOut()"  href="./#">Cerrar Sesión</a></li>
+        <li><a class="active" href="/">Inicio</a></li>
+        <li [class.hidden]="!isLogged" ><a  (click)="goToConfigPage()" >Configuración</a></li>
+        <li [class.hidden]="isLogged" ><a (click)="openModal(template)"  href="#">Iniciar Sesión</a></li>
+        <li [class.hidden]="!isLogged" ><a (click)="logOut()"  href="./#">Cerrar Sesión</a></li>
       </ul>
 
       <ng-template #template>

--- a/ClientApp/src/app/components/header/header.component.ts
+++ b/ClientApp/src/app/components/header/header.component.ts
@@ -1,6 +1,7 @@
 import { Component, OnInit, HostBinding, TemplateRef } from '@angular/core';
 import { BsModalRef, BsModalService } from 'ngx-bootstrap/modal';
 import { AuthService } from '../../services/auth/AuthService';
+import { Router, ActivatedRoute } from '../../../../node_modules/@angular/router';
 
 @Component({
   selector: 'app-header',
@@ -29,7 +30,9 @@ export class HeaderComponent implements OnInit {
     });
   }
 
-  constructor(private modalService: BsModalService, private auth: AuthService) { }
+  constructor(private modalService: BsModalService, private auth: AuthService,
+    private router: Router,
+    private route: ActivatedRoute) { }
 
   ngOnInit() {
   }
@@ -43,5 +46,9 @@ export class HeaderComponent implements OnInit {
   }
   get isLogged(): boolean {
     return this.auth.getUser() !== false;
+  }
+
+  goToConfigPage() {
+    this.router.navigateByUrl('/config') ;
   }
 }

--- a/ClientApp/src/app/components/indicator-detail/document-preview/document-preview.component.html
+++ b/ClientApp/src/app/components/indicator-detail/document-preview/document-preview.component.html
@@ -4,7 +4,10 @@
       <span aria-hidden="true">&times;</span>
     </button>
   </div>
-  <div class="modal-body">
+<div class="modal-body">
+  <div *ngIf="document">
+    Extension:{{document.extension}}
+
     <div *ngIf="document.extension!='.pdf'
     && document.extension!='.jpg'
     && document.extension!='.jpeg'
@@ -12,19 +15,19 @@
     && document.extension!='link'; else contentDiv">
       Lo sentimos. No existe una vista previa para este archivo.
     </div>
-    <ng-template #contentDiv>
-      <div *ngIf="loading" class="inner-loading-wheel">
-        <div class="loader-wheel"></div>
-      </div>
-      <div *ngIf="document.extension=='.pdf'">
-        <pdf-viewer src="{{'/api/Files/' + this.document.link}}" (after-load-complete)="loading=false">
-        </pdf-viewer>
-      </div>
-      <div *ngIf="document.extension=='.jpg' || document.extension=='.jpeg' || document.extension=='.png'">
-        <img src="{{'/api/Files/' + this.document.link}}" (load)="loading=false">
-      </div>
-      <iframe style="height:80vh; width:100%;" *ngIf="document.extension=='link'" 
-      [src]="this.document.link | safeDom" (load)="loading=false">
-      </iframe>
-    </ng-template>
   </div>
+  <ng-template #contentDiv>
+    <div *ngIf="loading" class="inner-loading-wheel">
+      <div class="loader-wheel"></div>
+    </div>
+    <div *ngIf="document.extension=='.pdf'">
+      <pdf-viewer src="{{'/api/Files/' + this.document.link}}" (after-load-complete)="loading=false">
+      </pdf-viewer>
+    </div>
+    <div *ngIf="document.extension=='.jpg' || document.extension=='.jpeg' || document.extension=='.png'">
+      <img src="{{'/api/Files/' + this.document.link}}" (load)="loading=false">
+    </div>
+    <iframe style="height:80vh; width:100%;" *ngIf="document.extension=='link'"
+            [src]="this.document.link | safeDom" (load)="loading=false"></iframe>
+  </ng-template>
+</div>

--- a/ClientApp/src/app/components/indicator-detail/indicator-detail-registry/indicator-detail-registry.component.scss
+++ b/ClientApp/src/app/components/indicator-detail/indicator-detail-registry/indicator-detail-registry.component.scss
@@ -15,7 +15,7 @@
 
 .card-header {
   padding: 1em;
-  border-radius: 0.5em;
+  //border-radius: 0.5em;
   font-size: 14px;
   border: 1px solid #c4c4c4;
   font-weight: bolder;

--- a/ClientApp/src/app/components/indicator-detail/indicator-detail-registry/indicator-detail-registry.component.ts
+++ b/ClientApp/src/app/components/indicator-detail/indicator-detail-registry/indicator-detail-registry.component.ts
@@ -205,7 +205,7 @@ export class IndicatorDetailRegistryComponent implements OnInit {
       type: 'warning',
       showCancelButton: true,
       confirmButtonText: 'Aceptar',
-      cancelButtonText: 'CANCELAR',
+      cancelButtonText: 'Cancelar',
       buttonsStyling: false,
       reverseButtons: true,
       confirmButtonClass: 'btn btn-sm btn-primary',

--- a/ClientApp/src/app/services/indicator-group/indicator-group.service.ts
+++ b/ClientApp/src/app/services/indicator-group/indicator-group.service.ts
@@ -60,4 +60,8 @@ export class IndicatorGroupService {
   getIndicatorGroupName(indicatorId: number): Observable<string> {
     return this.http.get<string>(IndicatorGroupService.NAME + indicatorId);
   }
+
+  deleteIndicatorGroup(indicatorGroup: IndicatorGroup): Observable<IndicatorGroup> {
+    return this.http.delete<IndicatorGroup>(IndicatorGroupService.API_URL + indicatorGroup.indicatorGroupID);
+  }
 }

--- a/ClientApp/src/app/services/indicator/indicator.service.ts
+++ b/ClientApp/src/app/services/indicator/indicator.service.ts
@@ -32,6 +32,10 @@ export class IndicatorService {
     return this.http.get<Indicator>(IndicatorService.INDICATORS_API + indicatorId);
   }
 
+  getIndicators(): Observable<Indicator[]> {
+    return this.http.get<Indicator[]>(IndicatorService.INDICATORS_API);
+  }
+
   getIndicatorYearRegistries(indicatorId: number, year: number): Observable<Indicator> {
     return this.http.get<Indicator>(IndicatorService.INDICATORS_API + indicatorId + '/' + year);
   }

--- a/ClientApp/src/app/services/indicator/indicator.service.ts
+++ b/ClientApp/src/app/services/indicator/indicator.service.ts
@@ -107,7 +107,7 @@ export class IndicatorService {
     return this.http.post<any>(IndicatorService.INDICATORS_API, indicator);
   }
 
-  deleteIndicator(indicador: Indicator) {
-    //return this.http.delete<any>
+  deleteIndicator(indicator: Indicator): Observable<Indicator> {
+    return this.http.delete<Indicator>(IndicatorService.INDICATORS_API + indicator.indicatorID);
   }
 }

--- a/ClientApp/src/app/services/indicator/indicator.service.ts
+++ b/ClientApp/src/app/services/indicator/indicator.service.ts
@@ -106,4 +106,8 @@ export class IndicatorService {
   addIndicator(indicator: Indicator): Observable<any> {
     return this.http.post<any>(IndicatorService.INDICATORS_API, indicator);
   }
+
+  deleteIndicator(indicador: Indicator) {
+    //return this.http.delete<any>
+  }
 }

--- a/Controllers/FilesController.cs
+++ b/Controllers/FilesController.cs
@@ -29,7 +29,6 @@ namespace ThinkAgroMetrics.Controllers
 
         // GET: api/Files/ASDKFJ"#L$"L#$J!#"#$JLSDG
         [HttpGet("{link}")]
-        [Authorize(Roles = "administrador,gestor_contenido")]
         public IActionResult Download([FromRoute] string link) 
         {
             string folderName = "Repository";
@@ -52,7 +51,6 @@ namespace ThinkAgroMetrics.Controllers
 
         // PUT: api/Files/5
         [HttpPut("{id}")]
-        [Authorize(Roles = "administrador")]
         public async Task<IActionResult> PutDocument([FromRoute] long id, [FromBody] Document document)
         {
             if (!ModelState.IsValid)

--- a/Controllers/IndicatorGroupsController.cs
+++ b/Controllers/IndicatorGroupsController.cs
@@ -25,7 +25,6 @@ namespace think_agro_metrics.Controllers
 
         // GET: api/IndicatorGroups
         [HttpGet]
-        [Authorize(Roles = "administrador,gestor_contenido")]
         public async Task<IActionResult> GetIndicatorGroups()
         {
             var indicatorGroups = await _context.IndicatorGroups
@@ -52,7 +51,6 @@ namespace think_agro_metrics.Controllers
 
         // GET: api/IndicatorGroups/5
         [HttpGet("{id}")]
-        [Authorize(Roles = "administrador,gestor_contenido")]
         public async Task<IActionResult> GetIndicatorGroup([FromRoute] long id)
         {
             if (!ModelState.IsValid)
@@ -76,7 +74,6 @@ namespace think_agro_metrics.Controllers
 
         // GET: api/IndicatorsGroups/Name/5
         [HttpGet("Name/{id}")]
-        [Authorize(Roles = "administrador,gestor_contenido")]
         public async Task<IActionResult> GetIndicatorGroupName([FromRoute] long id)
         {
             if (!ModelState.IsValid)
@@ -96,7 +93,6 @@ namespace think_agro_metrics.Controllers
 
         // PUT: api/IndicatorGroups/5
         [HttpPut("{id}")]
-        [Authorize(Roles = "administrador")]
         public async Task<IActionResult> PutIndicatorGroup([FromRoute] long id, [FromBody] IndicatorGroup indicatorGroup)
         {
             if (!ModelState.IsValid)
@@ -132,7 +128,6 @@ namespace think_agro_metrics.Controllers
 
         // POST: api/IndicatorGroups
         [HttpPost]
-        [Authorize(Roles = "administrador")]
         public async Task<IActionResult> PostIndicatorGroup([FromBody] IndicatorGroup indicatorGroup)
         {
             if (!ModelState.IsValid)
@@ -158,7 +153,6 @@ namespace think_agro_metrics.Controllers
 
         // DELETE: api/IndicatorGroups/5
         [HttpDelete("{id}")]
-        [Authorize(Roles = "administrador")]
         public async Task<IActionResult> DeleteIndicatorGroup([FromRoute] long id)
         {
             if (!ModelState.IsValid)
@@ -180,7 +174,6 @@ namespace think_agro_metrics.Controllers
 
         // GET: api/IndicatorGroups/Calculate/1 (group= 1)
         [Route("Calculate/{id:int}")]
-        [Authorize(Roles = "administrador,gestor_contenido")]
         public async Task<IActionResult> CalculateIndicators([FromRoute] int id)
         {
             if (!ModelState.IsValid)
@@ -217,7 +210,6 @@ namespace think_agro_metrics.Controllers
 
         // GET: api/IndicatorGroups/Calculate/1/2018 (group= 1, year= 2018)
         [Route("Calculate/{id:int}/{year:int}")]
-        [Authorize(Roles = "administrador,gestor_contenido")]
         public async Task<IActionResult> CalculateIndicators([FromRoute] int id, [FromRoute] int year)
         {
             if (!ModelState.IsValid)
@@ -254,7 +246,6 @@ namespace think_agro_metrics.Controllers
 
         // GET: api/IndicatorGroups/Calculate/1/2018/0 (group= 1, year= 2018, month= January)
         [Route("Calculate/{id:int}/{year:int}/{month:int}")]
-        [Authorize(Roles = "administrador,gestor_contenido")]
         public async Task<IActionResult> CalculateIndicators([FromRoute] int id, [FromRoute] int year, [FromRoute] int month)
         {
             if (!ModelState.IsValid)
@@ -294,7 +285,6 @@ namespace think_agro_metrics.Controllers
 
         // GET: api/IndicatorGroups/Goals/1 (group= 1)
         [Route("Goals/{id:long}")]
-        [Authorize(Roles = "administrador,gestor_contenido")]
         public async Task<IActionResult> GetGoalsIndicators([FromRoute] long id)
         {
             if (!ModelState.IsValid)
@@ -335,7 +325,6 @@ namespace think_agro_metrics.Controllers
 
         // GET: api/IndicatorGroups/Goals/1/2018 (group = 1, year = 2018)
         [Route("Goals/{id:long}/{year:int}")]
-        [Authorize(Roles = "administrador,gestor_contenido")]
         public async Task<IActionResult> GetGoalsIndicators([FromRoute] int id, [FromRoute] int year)
         {
             if (!ModelState.IsValid)
@@ -374,7 +363,6 @@ namespace think_agro_metrics.Controllers
 
         // GET: api/IndicatorGroups/Goals/1/2018/0 (group = 1, year = 2018, month = January)
         [Route("Goals/{id:long}/{year:int}/{month:int}")]
-        [Authorize(Roles = "administrador,gestor_contenido")]
         public async Task<IActionResult> GetGoalsIndicators([FromRoute] int id, [FromRoute] int year, [FromRoute] int month)
         {
             if (!ModelState.IsValid)

--- a/Controllers/IndicatorsController.cs
+++ b/Controllers/IndicatorsController.cs
@@ -27,11 +27,13 @@ namespace think_agro_metrics.Controllers
         [HttpGet]
         public async Task<IActionResult> GetIndicators()
         {
-            var indicators = await _context.Indicators
+            // I hope nobody needs this
+            /*var indicators = await _context.Indicators
                 .Include(x => x.Goals)
                 .Include(x => x.Registries)                
                 .ThenInclude(x => x.Documents).ToListAsync();
-
+            */
+            var indicators = await _context.Indicators.ToListAsync();
             return Ok(indicators);
         }
 

--- a/Controllers/IndicatorsController.cs
+++ b/Controllers/IndicatorsController.cs
@@ -25,7 +25,6 @@ namespace think_agro_metrics.Controllers
 
         // GET: api/Indicators
         [HttpGet]
-        [Authorize(Roles = "administrador,gestor_contenido")]
         public async Task<IActionResult> GetIndicators()
         {
             var indicators = await _context.Indicators
@@ -38,7 +37,6 @@ namespace think_agro_metrics.Controllers
 
         // GET: api/Indicators/5
         [HttpGet("{id:long}")]
-        [Authorize(Roles = "administrador,gestor_contenido")]
         public async Task<IActionResult> GetIndicator([FromRoute] long id)
         {            
             if (!ModelState.IsValid)
@@ -63,7 +61,6 @@ namespace think_agro_metrics.Controllers
 
         // GET: api/Indicators/5/2018
         [HttpGet("{id:long}/{year:int}")]
-        [Authorize(Roles = "administrador,gestor_contenido")]
         public async Task<IActionResult> GetIndicatorRegitriesByYear([FromRoute] long id, [FromRoute] int year)
         {
             if(!ModelState.IsValid)
@@ -95,7 +92,6 @@ namespace think_agro_metrics.Controllers
 
         // GET: api/Indicators/5/2018/1
         [HttpGet("{id:long}/{year:int}/{month:int}")]
-        [Authorize(Roles = "administrador,gestor_contenido")]
         public async Task<IActionResult> GetIndicatorRegitriesByYearMonth([FromRoute] long id, [FromRoute] int year, [FromRoute] int month)
         {
             if(!ModelState.IsValid)
@@ -130,7 +126,6 @@ namespace think_agro_metrics.Controllers
 
         // GET: api/Indicators/Goals/1
         [HttpGet("Goals/{id:long}")]
-        [Authorize(Roles = "administrador,gestor_contenido")]
         public async Task<IActionResult> GetIndicatorGoals([FromRoute] long id)
         {
             if(!ModelState.IsValid)
@@ -163,7 +158,6 @@ namespace think_agro_metrics.Controllers
 
         // GET: api/Indicators/Goals/1/2018
         [HttpGet("Goals/{id:long}/{year:int}")]
-        [Authorize(Roles = "administrador,gestor_contenido")]
         public async Task<IActionResult> GetIndicatorGoals([FromRoute] long id, [FromRoute] int year)
         {
             if(!ModelState.IsValid)
@@ -196,7 +190,6 @@ namespace think_agro_metrics.Controllers
 
         // GET: api/Indicators/Goals/1/2018/0 (indicator 1, year 2018, month January)
         [HttpGet("Goals/{id:long}/{year:int}/{month:int}")]
-        [Authorize(Roles = "administrador,gestor_contenido")]
         public async Task<IActionResult> GetIndicatorGoals([FromRoute] long id, [FromRoute] int year, [FromRoute] int month)
         {
             if(!ModelState.IsValid)
@@ -218,7 +211,6 @@ namespace think_agro_metrics.Controllers
 
         // GET: api/Indicators/Calculate
         [Route("Calculate")]
-        [Authorize(Roles = "administrador,gestor_contenido")]
         public async Task<IActionResult> CalculateIndicators()
         {
             if (!ModelState.IsValid)
@@ -252,7 +244,6 @@ namespace think_agro_metrics.Controllers
         
         // GET: api/Indicators/Calculate/2018
         [Route("Calculate/{year:int}")]
-        [Authorize(Roles = "administrador,gestor_contenido")]
         public async Task<IActionResult> CalculateIndicators([FromRoute] int year)
         {
             if (!ModelState.IsValid)
@@ -286,7 +277,6 @@ namespace think_agro_metrics.Controllers
 
         // GET: api/Indicators/Calculate/2018/1
         [Route("Calculate/{year:int}/{month:int}")]
-        [Authorize(Roles = "administrador,gestor_contenido")]
         public async Task<IActionResult> CalculateIndicators([FromRoute] int year, [FromRoute] int month)
         {
             if (!ModelState.IsValid)
@@ -323,7 +313,6 @@ namespace think_agro_metrics.Controllers
 
         // GET: api/Indicators/Calculate/5 // Calculate Indicator with ID 5 for all years
         [Route("Calculate/{id:long}")]
-        [Authorize(Roles = "administrador,gestor_contenido")]
         public async Task<ActionResult> CalculateIndicator([FromRoute] long id)
         {
             if (!ModelState.IsValid)
@@ -350,7 +339,6 @@ namespace think_agro_metrics.Controllers
 
         // GET: api/Indicators/Calculate/5/2018 // Calculate Indicator with ID 5 for a selected year
         [Route("Calculate/{id:long}/{year:int}")]
-        [Authorize(Roles = "administrador,gestor_contenido")]
         public async Task<ActionResult> CalculateIndicatorByYear([FromRoute] long id, [FromRoute] int year)
         {
             if (!ModelState.IsValid)
@@ -377,7 +365,6 @@ namespace think_agro_metrics.Controllers
 
         // GET: api/Indicators/Calculate/5/2018/0 // Calculate Indicator with ID 5 for a selected year and selected month
         [Route("Calculate/{id:long}/{year:int}/{month:int}")]
-        [Authorize(Roles = "administrador,gestor_contenido")]
         public async Task<ActionResult> CalculateIndicatorByYearMonth([FromRoute] long id, [FromRoute] int year, [FromRoute] int month)
         {
             if (!ModelState.IsValid)
@@ -407,7 +394,6 @@ namespace think_agro_metrics.Controllers
 
         // PUT: api/Indicators/5
         [HttpPut("{id}")]
-        [Authorize(Roles = "administrador")]
         public async Task<IActionResult> PutIndicator([FromRoute] long id, [FromBody] Indicator indicator)
         {
             if (!ModelState.IsValid)
@@ -443,7 +429,6 @@ namespace think_agro_metrics.Controllers
 
         // POST: api/Indicators
         [HttpPost]
-        [Authorize(Roles = "administrador")]
         public async Task<IActionResult> PostIndicator([FromBody] Indicator indicator)
         {
             if (!ModelState.IsValid)
@@ -469,7 +454,6 @@ namespace think_agro_metrics.Controllers
 
         // DELETE: api/Indicators/5
         [HttpDelete("{id}")]
-        [Authorize(Roles = "administrador")]
         public async Task<IActionResult> DeleteIndicator([FromRoute] long id)
         {
             if (!ModelState.IsValid)
@@ -496,7 +480,6 @@ namespace think_agro_metrics.Controllers
 
         // ADD REGISTRY: api/Indicators/5/AddRegistry
         [HttpPost("{indicatorId}/AddRegistry")]
-        [Authorize(Roles = "administrador")]
         public async Task<IActionResult> AddRegistry([FromRoute] long indicatorId,
             [FromBody] DefaultRegistry registry)
         {
@@ -536,7 +519,6 @@ namespace think_agro_metrics.Controllers
 
         // GET: api/Indicators/1/GoalsList
         [HttpGet("{id:long}/GoalsList")]
-        [Authorize(Roles = "administrador,gestor_contenido")]
         public async Task<IActionResult> GetIndicatorGoalsList([FromRoute] long id)
         {
             if (!ModelState.IsValid)
@@ -558,7 +540,6 @@ namespace think_agro_metrics.Controllers
 
         // POST: api/Indicators/1/GoalsList
         [HttpPost("{idIndicator:long}/GoalsList")]
-        [Authorize(Roles = "administrador")]
         public async Task<IActionResult> PostGoalsList([FromRoute] long idIndicator, [FromBody] Goal[] goals)
         {
             if (!ModelState.IsValid)
@@ -574,7 +555,6 @@ namespace think_agro_metrics.Controllers
 
         // PUT: api/Indicators/Goal/7
         [HttpPut("Goal/{id:long}")]
-        [Authorize(Roles = "administrador")]
         public async Task<IActionResult> PutIndicatorGoal([FromBody] Goal goal, [FromRoute] long id)
         {
             if (!ModelState.IsValid)

--- a/Controllers/RegistriesController.cs
+++ b/Controllers/RegistriesController.cs
@@ -84,7 +84,6 @@ namespace think_agro_metrics.Controllers
 
         // GET: api/Registries
         [HttpGet]
-        [Authorize(Roles = "administrador,gestor_contenido")]
         public async Task<IActionResult> GetRegistries()
         {
             var registries = await _context.Registries.Include(r => r.Documents).ToListAsync();
@@ -93,7 +92,6 @@ namespace think_agro_metrics.Controllers
 
         // GET: api/Registries/5
         [HttpGet("{id}")]
-        [Authorize(Roles = "administrador,gestor_contenido")]
         public async Task<IActionResult> GetRegistry([FromRoute] long id)
         {
             if (!ModelState.IsValid)
@@ -113,7 +111,6 @@ namespace think_agro_metrics.Controllers
 
         // GET: api/Registries/External
         [HttpGet("External")]
-        [Authorize(Roles = "administrador,gestor_contenido")]
         public async Task<IActionResult> GetExternalRegistries()
         {
             var payload = this.CreateDataObject(new {
@@ -181,7 +178,6 @@ namespace think_agro_metrics.Controllers
 
         // PUT: api/Registries/DefaultRegistry/5
         [HttpPut("DefaultRegistry/{id}")]
-        [Authorize(Roles = "administrador")]
         public async Task<IActionResult> PutRegistry([FromRoute] long id, [FromBody] DefaultRegistry registry)
         {   
             if (!ModelState.IsValid)
@@ -217,7 +213,6 @@ namespace think_agro_metrics.Controllers
 
         // PUT: api/Registries/QuantityRegistry/5
         [HttpPut("QuantityRegistry/{id}")]
-        [Authorize(Roles = "administrador")]
         public async Task<IActionResult> PutRegistry([FromRoute] long id, [FromBody] QuantityRegistry registry)
         {   
             if (!ModelState.IsValid)
@@ -253,7 +248,6 @@ namespace think_agro_metrics.Controllers
 
         // PUT: api/Registries/PercentRegistry/5
         [HttpPut("PercentRegistry/{id}")]
-        [Authorize(Roles = "administrador")]
         public async Task<IActionResult> PutRegistry([FromRoute] long id, [FromBody] PercentRegistry registry)
         {   
             if (!ModelState.IsValid)
@@ -289,7 +283,6 @@ namespace think_agro_metrics.Controllers
 
        // ADD REGISTRY: api/Indicators/5/AddRegistry
         [HttpPost("{indicatorId}/DefaultRegistry")]
-        [Authorize(Roles = "administrador")]
         public async Task<IActionResult> DefaultRegistry([FromRoute] long indicatorId,
             [FromBody] DefaultRegistry registry)
         {
@@ -341,7 +334,6 @@ namespace think_agro_metrics.Controllers
 
         // ADD REGISTRY: api/Indicators/5/AddRegistry
         [HttpPost("{indicatorId}/QuantityRegistry")]
-        [Authorize(Roles = "administrador")]
         public async Task<IActionResult> QuantityRegistry([FromRoute] long indicatorId,
             [FromBody] QuantityRegistry registry)
         {
@@ -388,7 +380,6 @@ namespace think_agro_metrics.Controllers
 
         // ADD REGISTRY: api/Indicators/5/AddRegistry
         [HttpPost("{indicatorId}/PercentRegistry")]
-        [Authorize(Roles = "administrador")]
         public async Task<IActionResult> PercentRegistry([FromRoute] long indicatorId,
             [FromBody] PercentRegistry registry)
         {
@@ -436,7 +427,6 @@ namespace think_agro_metrics.Controllers
 
         // DELETE: api/Registries/Documents/5
         [HttpDelete("Documents/{id}")]
-        [Authorize(Roles = "administrador")]
         public async Task<IActionResult> DeleteDocument([FromRoute] long id)
         {
             if(!ModelState.IsValid)
@@ -466,7 +456,6 @@ namespace think_agro_metrics.Controllers
 
         // DELETE: api/Registries/5
         [HttpDelete("{id}")]
-        [Authorize(Roles = "administrador")]
         public async Task<IActionResult> DeleteRegistry([FromRoute] long id)
         {
             if (!ModelState.IsValid)
@@ -503,7 +492,6 @@ namespace think_agro_metrics.Controllers
 
         // ADD LinkDocument: api/Registries/5/AddLinkDocument
         [HttpPost("{id}/AddLinkDocument")]
-        [Authorize(Roles = "administrador")]
         public async Task<IActionResult> AddLinkDocument([FromRoute] long id,
             [FromBody] Document document)
         {
@@ -554,7 +542,6 @@ namespace think_agro_metrics.Controllers
 
         // ADD FileDocument: api/Registries/5/AddFileDocument
         [HttpPost("{id}/AddFileDocument"), DisableRequestSizeLimit]
-        [Authorize(Roles = "administrador")]
         public async Task<IActionResult> AddFileDocument([FromRoute] long id)
         {
             try


### PR DESCRIPTION
### Modify
- Api endpoints (`DELETE`) for IndicatorGroup, Indicator and Registry.
So, if one entity of those gets deleted, a _kind of_ "ON DELETE CASCADE" will be executed on the database/model and all the pdf files asociated on the server folder.
For Example, if a IndicatorGroup gets deleted, every Indicator asociated with that IndicatorGroup will be deleted. When a Indicator gets deleted, every Registry that belongs to that Indicator will be deleted. And finally, When a Registry gets deleted, every document will be deleted, even those pdf files stored on th server.

### Add
- `IndicatorService.deleteIndicator(indicator)` method that makes the http call to delete the specified indicator.
- `IndicatorGroupService.deleteIndicatorGroup(indicatorGroup)` method that makes the http call to delete the specified indicator group.
- `config-home` component that shows a list of indicator groups and indicators to "manage" them.

### Note
The design for `config-home` isn't approved for design team, because there wasn't a design for this view.
It's priority to implement the functionality, so here is the PR. ~But I'm gonna work on a better UI design, hopefully tonight~ (done).

Ps: The auth on api calls (on this branch) got deleted.
Ps2: UI improved