### PR TITLE
Feature/Set role permissions when indicator is created

### DIFF
--- a/ClientApp/src/app/app.module.ts
+++ b/ClientApp/src/app/app.module.ts
@@ -57,7 +57,9 @@ import { esLocale } from 'ngx-bootstrap/locale';
 import { SafeDomPipe } from './shared/safe-dom.pipe';
 import { NotificationService } from './services/alerts/notification.service';
 import { ChartComponent } from './components/indicator-detail/chart/chart.component';
+import { ConfigHomeComponent } from './components/config-home/config-home.component';
 import { PreviousRouteService } from './services/previous-route/previous-route.service';
+import { IndicatorGroupEditorComponent } from './components/config-home/indicator-group-editor/indicator-group-editor.component';
 
 defineLocale('es', esLocale);
 
@@ -91,7 +93,9 @@ defineLocale('es', esLocale);
     LinkDocumentSubformComponent,
     FileDocumentSubformComponent,
     SafeDomPipe,
-    ChartComponent
+    ChartComponent,
+    ConfigHomeComponent,
+    IndicatorGroupEditorComponent
   ],
   imports: [
     BsDropdownModule.forRoot(),
@@ -125,6 +129,11 @@ defineLocale('es', esLocale);
       {
         path: '',
         component: ResultHomeComponent,
+        canActivate: [CanActivateUser]
+      },
+      {
+        path: 'config',
+        component: ConfigHomeComponent,
         canActivate: [CanActivateUser]
       },
       {

--- a/ClientApp/src/app/app.module.ts
+++ b/ClientApp/src/app/app.module.ts
@@ -60,6 +60,7 @@ import { ChartComponent } from './components/indicator-detail/chart/chart.compon
 import { ConfigHomeComponent } from './components/config-home/config-home.component';
 import { PreviousRouteService } from './services/previous-route/previous-route.service';
 import { IndicatorGroupEditorComponent } from './components/config-home/indicator-group-editor/indicator-group-editor.component';
+import { RoleService } from './services/role/role.service';
 
 defineLocale('es', esLocale);
 
@@ -157,6 +158,7 @@ defineLocale('es', esLocale);
     NotificationService,
     LoaderService,
     PreviousRouteService,
+    RoleService,
     {
       provide: HTTP_INTERCEPTORS,
       useClass: LoaderInterceptor,
@@ -165,7 +167,7 @@ defineLocale('es', esLocale);
     {
       provide: HTTP_INTERCEPTORS,
       useClass: TokenInterceptor,
-      multi: true
+      multi: true,
     }
   ],
   bootstrap: [AppComponent]

--- a/ClientApp/src/app/app.module.ts
+++ b/ClientApp/src/app/app.module.ts
@@ -54,6 +54,7 @@ import { LinkDocumentSubformComponent } from './components/registry-form/link-do
 import { FileDocumentSubformComponent } from './components/registry-form/file-document-subform/file-document-subform.component';
 import { defineLocale } from 'ngx-bootstrap/chronos';
 import { esLocale } from 'ngx-bootstrap/locale';
+import { IndicatorEditorComponent } from './components/indicator-detail/indicator-editor/indicator-editor.component';
 import { SafeDomPipe } from './shared/safe-dom.pipe';
 import { NotificationService } from './services/alerts/notification.service';
 import { ChartComponent } from './components/indicator-detail/chart/chart.component';
@@ -93,6 +94,7 @@ defineLocale('es', esLocale);
     AddDocumentFormComponent,
     LinkDocumentSubformComponent,
     FileDocumentSubformComponent,
+    IndicatorEditorComponent,
     SafeDomPipe,
     ChartComponent,
     ConfigHomeComponent,

--- a/ClientApp/src/app/components/config-home/config-home.component.html
+++ b/ClientApp/src/app/components/config-home/config-home.component.html
@@ -1,0 +1,93 @@
+<!-- Head page section================================================== -->
+<section>
+  <div id="head-page-section" class="l-grey-bg head-page-section">
+    <div class="container">
+      <app-navigation-buttons></app-navigation-buttons>
+      <div class="row">
+        <div class="col-md-12 col-sm-12">
+          <div class="head-title">
+            <h1>
+              Configuración
+            </h1>
+          </div>
+          <!-- end subsection-text -->
+        </div>
+        <!-- end col-md-8 -->
+      </div>
+      <!-- end row -->
+    </div>
+    <!-- end container -->
+  </div>
+  <!-- end head-page-section -->
+</section>
+
+<section>
+
+  <div class="container">
+    <div style="margin-top: 10px;">
+      <div class="row">
+        <div class="col-xs-12 col-sm-12 col-md-12">
+          <h2>
+            Listado de resultados esperados
+          </h2>
+        </div>
+      </div>
+      <div *ngIf="indicatorsGroups$ | async as indicatorGroups">
+        <ngb-accordion [closeOthers]="true" activeIds="static-1">
+          <ng-template ngFor let-indicatorGroup [ngForOf]="indicatorGroups" let-i="index">
+            <ngb-panel>
+              <ng-template ngbPanelTitle style="padding: 1em; border-radius: 0.5em; font-size: 14px; border: 5px solid #c4c4c4 !important; font-weight: bolder;">
+                <div class="row clickable" style="padding: 20px; margin-bottom: 5px; margin-top: 5px;">
+                    <div class="col-xs-7 col-sm-7 col-md-7">
+                      <h5 class="fixh5">
+                        {{ indicatorGroup.name }}
+                      </h5>
+                    </div>
+                    <div class="col-xs-3 col-sm-3 col-md-3">
+                      <button class="btn btn-xs btn-warning" type="button" (click)="openModalEdit($event, editIndicatorGroup,indicatorGroup)">Modificar</button>
+                      <button class="btn btn-xs btn-danger" type="button" (click)="deleteIndicatorGroup($event, indicatorGroup)">ELIMINAR</button>
+                    </div>
+                    <div class="col-xs-1 col-sm-1 col-md-1 pull-right">
+                      <span class="pull-right centered-vertical glyphicon glyphicon-menu-down" style="font-size: 24px; vertical-align: top; padding-top: -10px;"></span>
+                    </div>
+                </div>
+              </ng-template>
+              <ng-template ngbPanelContent>
+                <ng-template ngFor let-indicator [ngForOf]="indicatorGroup.indicators">
+                  <div class="row" style="margin-bottom: 5px; margin-top: 5px;">
+                    <div class="col-xs-10 col-sm-10 col-md-10">
+                      <h5 class="fixh5">
+                        <strong>{{ indicator.name }}</strong>
+                      </h5>
+
+                    </div>
+                    <div class="col-xs-2 col-sm-2 col-md-2">
+                        <button class="btn btn-xs btn-danger" [disabled]="indicator.registriesType == externalRegistry" type="button" (click)="deleteIndicator($event, indicator)">ELIMINAR</button>
+                    </div>
+                  </div>
+                </ng-template>
+              </ng-template>
+            </ngb-panel>
+          </ng-template>
+
+        </ngb-accordion>
+      </div>
+    </div>
+
+
+
+  </div>
+  <!--End Container-->
+
+</section>
+
+<!-- Modal Edit Indicator -->
+<ng-template #editIndicatorGroup>
+  <div class="modal-header" tabindex="-1">
+    <h4 class="modal-title pull-left">Modificar resultado esperado</h4>
+    <button type="button" class="close pull-right" aria-label="Close" (click)="editIndicatorGroupModalRef.hide()">
+      <span aria-hidden="true">&times;</span>
+    </button>
+  </div>
+  <app-indicator-group-editor [modalRef]="editIndicatorGroupModalRef" [indicatorGroup]="selectedIndicatorGroup" (updateEvent)="update()"></app-indicator-group-editor>
+</ng-template>

--- a/ClientApp/src/app/components/config-home/config-home.component.scss
+++ b/ClientApp/src/app/components/config-home/config-home.component.scss
@@ -1,0 +1,38 @@
+.btn-cancel {
+  margin-right: 5px;
+}
+.card {
+  margin: 1em;
+}
+
+.card-body {
+  margin: 1em;
+  padding: 1em;
+  display: none;
+  padding-top: 10px;
+}
+// This stuff matters!
+.show {
+  overflow: hidden;
+  transition: transform 2s ease-out !important; // note that we're transitioning transform, not height!
+  height: 100%;
+  transform: scaleY(1); // implicit, but good to specify explicitly
+  transform-origin: top; // keep the top of the element in the same place. this is optional.
+}
+
+.card-header {
+  padding: 1em;
+  //border-radius: 0.5em;
+  font-size: 14px;
+  border: 1px solid #c4c4c4;
+  font-weight: bolder;
+
+  a {
+    color: black;
+  }
+}
+.head-page-section{
+    margin-top: 80px !important;
+}
+
+

--- a/ClientApp/src/app/components/config-home/config-home.component.spec.ts
+++ b/ClientApp/src/app/components/config-home/config-home.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ConfigHomeComponent } from './config-home.component';
+
+describe('ConfigHomeComponent', () => {
+  let component: ConfigHomeComponent;
+  let fixture: ComponentFixture<ConfigHomeComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ ConfigHomeComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(ConfigHomeComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/ClientApp/src/app/components/config-home/config-home.component.ts
+++ b/ClientApp/src/app/components/config-home/config-home.component.ts
@@ -1,0 +1,132 @@
+import {Component, OnInit, ViewEncapsulation, TemplateRef} from '@angular/core';
+import { Observable } from '../../../../node_modules/rxjs/Observable';
+
+import {BsModalRef, BsModalService} from "ngx-bootstrap";
+
+// Models
+import { Indicator } from '../../shared/models/indicator';
+import { IndicatorGroup } from '../../shared/models/indicatorGroup';
+import { RegistryType } from '../../shared/models/registryType';
+
+// services
+import { IndicatorService } from '../../services/indicator/indicator.service';
+import { IndicatorGroupService } from '../../services/indicator-group/indicator-group.service';
+import { NotificationService } from '../../services/alerts/notification.service';
+
+import swal from 'sweetalert2';
+
+@Component({
+  selector: 'app-config-home',
+  templateUrl: './config-home.component.html',
+  styleUrls: ['./config-home.component.scss'],
+  encapsulation: ViewEncapsulation.None
+})
+export class ConfigHomeComponent implements OnInit {
+
+  indicatorsGroups$: Observable<IndicatorGroup[]>;
+  public editIndicatorGroupModalRef: BsModalRef;
+
+  public selectedIndicatorGroup: IndicatorGroup;
+
+  public  externalRegistry = RegistryType.ExternalRegistry;
+
+  constructor(private indicatorService: IndicatorService,
+              private indicatorGroupService: IndicatorGroupService,
+              private notificationService: NotificationService,
+              private modalService: BsModalService) { }
+
+  ngOnInit() {
+    this.indicatorsGroups$ = this.indicatorGroupService.getIndicatorGroups();
+  }
+
+  openModalEdit($event: any, template: TemplateRef<any>, indicatorGroup: IndicatorGroup) {
+    if ($event) {
+      $event.stopPropagation();
+      $event.preventDefault();
+    }
+
+    this.selectedIndicatorGroup = indicatorGroup;
+    this.editIndicatorGroupModalRef = this.modalService.show(template);
+  }
+
+  deleteIndicator($event: any, indicator: Indicator) {
+    if ($event) {
+      $event.stopPropagation();
+      $event.preventDefault();
+    }
+
+    this.confirmDeleteIndicator(indicator.name).then( result => {
+      if (result.value) {
+        this.indicatorService.deleteIndicator(indicator).subscribe(data =>{
+          this.notificationService.showToaster('Indicador eliminado', 'success');
+          this.indicatorsGroups$ = this.indicatorGroupService.getIndicatorGroups();
+        });
+      } else {
+        // Do nothing
+      }
+    }, error =>{
+      this.notificationService.showToaster('Error al eliminar el registro', 'error');
+    });
+  }
+
+  deleteIndicatorGroup($event: any, indicatorGroup: IndicatorGroup) {
+    if ($event) {
+      $event.stopPropagation();
+      $event.preventDefault();
+    }
+
+    this.confirmDeleteIndicatorGroup(indicatorGroup.name).then( result => {
+      if (result.value) {
+        this.indicatorGroupService.deleteIndicatorGroup(indicatorGroup).subscribe( data => {
+          this.notificationService.showToaster('Resultado esperado eliminado', 'success');
+          this.indicatorsGroups$ = this.indicatorGroupService.getIndicatorGroups();
+        });
+      } else {
+        // Do nothing
+      }
+    },error =>{
+        this.notificationService.showToaster('Error al eliminar el resultado esperado', 'error');
+    });
+  }
+
+  public update() {
+    this.indicatorsGroups$ = this.indicatorGroupService.getIndicatorGroups();
+  }
+
+  private confirmDeleteIndicator(name: string) {
+    return swal({
+      title: 'Eliminar indicador',
+      html: '<h6>¿Está seguro que desea eliminar el indicador <br>"' + name + '"?</h6><br>Esta acción no puede ser revertida y se perderán todos los datos relacionados' +
+      '<hr style="margin-top: 15px !important; margin-bottom: 2.5px !important;">',
+      type: 'warning',
+      showCancelButton: true,
+      confirmButtonText: 'Aceptar',
+      cancelButtonText: 'CANCELAR',
+      buttonsStyling: false,
+      reverseButtons: true,
+      confirmButtonClass: 'btn btn-sm btn-primary',
+      cancelButtonClass: 'btn btn-sm btn-clean-2 btn-cancel',
+      allowOutsideClick: false,
+      allowEscapeKey: false
+    });
+  }
+
+  private confirmDeleteIndicatorGroup(name: string) {
+    return swal({
+      title: 'Eliminar resultado esperado',
+      html: '<h6>¿Está seguro que desea eliminar el resultado<br>"' + name + '"?</h6><br>Esta acción no puede ser revertida y se perderán todos los datos relacionados' +
+      '<hr style="margin-top: 15px !important; margin-bottom: 2.5px !important;">',
+      type: 'warning',
+      showCancelButton: true,
+      confirmButtonText: 'Aceptar',
+      cancelButtonText: 'CANCELAR',
+      buttonsStyling: false,
+      reverseButtons: true,
+      confirmButtonClass: 'btn btn-sm btn-primary',
+      cancelButtonClass: 'btn btn-sm btn-clean-2 btn-cancel',
+      allowOutsideClick: false,
+      allowEscapeKey: false
+    });
+  }
+
+}

--- a/ClientApp/src/app/components/config-home/indicator-group-editor/indicator-group-editor.component.html
+++ b/ClientApp/src/app/components/config-home/indicator-group-editor/indicator-group-editor.component.html
@@ -1,0 +1,25 @@
+<form #editIndicatorGroupForm="ngForm" (ngSubmit)="onSubmit()">
+  <div class="modal-body">
+    <div class="row">
+      <div class="col-xs-12 col-sm-12 col-md-12">
+        <h4 class="head-project-title">Información Básica</h4>
+      </div>
+    </div>
+    <div class="row">
+      <div class="form-group col-sm-12 col-md-12">
+        <label>Nombre del resultado esperado</label>
+        <input type="text"  class="form-control" id="name" required [(ngModel)]="editedIndicatorGroup.name" name="name" #name="ngModel" />
+        <div [hidden]="name.valid || name.pristine"
+             class="alert alert-danger">
+          Nombre no puede estar vacio
+        </div>
+      </div>
+    </div>
+
+
+  </div>
+  <div class="modal-footer"> <!--modal-footer needed, in other case, the button will be outside the modal-->
+    <button type="button" (click)="modalRef.hide()" class="btn btn-sm btn-clean-2" ng-click=cancel()>Cancelar</button>
+    <button type="submit" class="btn btn-sm btn-primary" [disabled]="!editIndicatorGroupForm.form.valid">Aceptar</button>
+  </div>
+</form>

--- a/ClientApp/src/app/components/config-home/indicator-group-editor/indicator-group-editor.component.spec.ts
+++ b/ClientApp/src/app/components/config-home/indicator-group-editor/indicator-group-editor.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { IndicatorGroupEditorComponent } from './indicator-group-editor.component';
+
+describe('IndicatorGroupEditorComponent', () => {
+  let component: IndicatorGroupEditorComponent;
+  let fixture: ComponentFixture<IndicatorGroupEditorComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ IndicatorGroupEditorComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(IndicatorGroupEditorComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/ClientApp/src/app/components/config-home/indicator-group-editor/indicator-group-editor.component.ts
+++ b/ClientApp/src/app/components/config-home/indicator-group-editor/indicator-group-editor.component.ts
@@ -1,0 +1,70 @@
+import {Component, OnInit, Input, Output, EventEmitter} from '@angular/core';
+
+// Models
+import { IndicatorGroup } from '../../../shared/models/indicatorGroup';
+
+// Services
+import { IndicatorGroupService } from '../../../services/indicator-group/indicator-group.service';
+import {NotificationService} from '../../../services/alerts/notification.service';
+
+
+import {BsModalRef} from 'ngx-bootstrap';
+
+import swal from 'sweetalert2';
+
+@Component({
+  selector: 'app-indicator-group-editor',
+  templateUrl: './indicator-group-editor.component.html',
+  styleUrls: ['./indicator-group-editor.component.css']
+})
+export class IndicatorGroupEditorComponent implements OnInit {
+
+  @Input()
+  indicatorGroup: IndicatorGroup;
+
+  @Input()
+  modalRef: BsModalRef;
+
+  @Output()
+  public updateEvent = new EventEmitter();
+
+
+  public editedIndicatorGroup: IndicatorGroup;
+
+  constructor(private service: IndicatorGroupService,
+              private notificationService: NotificationService) { }
+
+  ngOnInit() {
+    this.editedIndicatorGroup = JSON.parse(JSON.stringify(this.indicatorGroup));
+  }
+
+  onSubmit() {
+    this.service.editIndicatorGroup(this.editedIndicatorGroup).subscribe(data =>{
+      if (data) {
+        this.notificationService.showToaster('Resultado esperado editado', 'success');
+        this.updateEvent.emit('Resultado espero editado');
+      } else {
+        this.duplicateNameAlert();
+      }
+    },
+      error1 => {
+      this.notificationService.showToaster('Error al editar el resultado esperado', 'error');
+    });
+    this.modalRef.hide();
+  }
+
+  private duplicateNameAlert() {
+    swal({
+      title: 'Error al editar el resultado esperado',
+      html: '<h6> Ya existe un resultado esperado con el nombre "' + this.editedIndicatorGroup.name + '"</h6>',
+      type: 'warning',
+      confirmButtonText: 'Aceptar',
+      buttonsStyling: false,
+      confirmButtonClass: 'btn btn-sm btn-primary',
+      allowOutsideClick: false,
+      allowEscapeKey: false
+    });
+  }
+
+
+}

--- a/ClientApp/src/app/components/header/header.component.html
+++ b/ClientApp/src/app/components/header/header.component.html
@@ -12,6 +12,7 @@
       <ul class="nav navbar-nav navbar-right">
           <li><a class="active" href="/">Inicio</a></li>
           <li *ngIf = "isLogged"> <a (click)="openModalReport(generator)"  href="javascript:void(0)" onclick="return false;">Generar Informe</a></li> <!-- Yo lo puse-->
+          <li [class.hidden]="!isLogged" ><a  (click)="goToConfigPage()" >Configuración</a></li>
           <li [class.hidden]="isLogged" ><a (click)="openModal(template)" href="javascript:void(0)"  >Iniciar Sesión</a></li>
           <li [class.hidden]="!isLogged" ><a (click)="logOut()" href="javascript:void(0)"  >Cerrar Sesión</a></li>
       </ul>

--- a/ClientApp/src/app/components/header/header.component.ts
+++ b/ClientApp/src/app/components/header/header.component.ts
@@ -1,6 +1,8 @@
 import { Component, OnInit, HostBinding, TemplateRef } from '@angular/core';
 import { BsModalRef, BsModalService } from 'ngx-bootstrap/modal';
 import { AuthService } from '../../services/auth/AuthService';
+import { Router, ActivatedRoute } from '../../../../node_modules/@angular/router';
+
 import {IndicatorGroup} from '../../shared/models/indicatorGroup';
 import {IndicatorGroupService} from '../../services/indicator-group/indicator-group.service';
 import { Observable } from 'rxjs/Observable';
@@ -17,7 +19,7 @@ export class HeaderComponent implements OnInit {
   };
   email: string;
   password: string;
-  public indicatorGroupsComplete$ : Observable<IndicatorGroup[]>; 
+  public indicatorGroupsComplete$ : Observable<IndicatorGroup[]>;
   authorize() {
     this.auth.auth({
       email: this.email,
@@ -30,26 +32,35 @@ export class HeaderComponent implements OnInit {
       this.password = '';
     });
   }
-  
-  constructor(private service: IndicatorGroupService, private modalService: BsModalService, private auth: AuthService) { }
+
+  constructor(private service: IndicatorGroupService,
+              private modalService: BsModalService,
+              private auth: AuthService,
+              private router: Router,
+              private route: ActivatedRoute) { }
 
   ngOnInit() {
-    this.indicatorGroupsComplete$ = this.service.getIndicatorGroupsComplete(); 
+    this.indicatorGroupsComplete$ = this.service.getIndicatorGroupsComplete();
   }
 
   openModal(template: TemplateRef<any>) {
     this.modalRef = this.modalService.show(template, this.config);
   }
 
-  openModalReport(template: TemplateRef<any>) 
+  openModalReport(template: TemplateRef<any>)
   {
     this.modalRef = this.modalService.show(template,  {class: 'modal-lg modal-md'});
   }
 
   logOut() {
     this.auth.signOut().subscribe();
+    this.router.navigateByUrl('/welcome') ;
   }
   get isLogged(): boolean {
     return this.auth.getUser() !== false;
+  }
+
+  goToConfigPage() {
+    this.router.navigateByUrl('/config') ;
   }
 }

--- a/ClientApp/src/app/components/indicator-detail/document-preview/document-preview.component.html
+++ b/ClientApp/src/app/components/indicator-detail/document-preview/document-preview.component.html
@@ -4,7 +4,10 @@
       <span aria-hidden="true">&times;</span>
     </button>
   </div>
-  <div class="modal-body">
+<div class="modal-body">
+  <div *ngIf="document">
+    Extension:{{document.extension}}
+
     <div *ngIf="document.extension!='.pdf'
     && document.extension!='.jpg'
     && document.extension!='.jpeg'
@@ -12,19 +15,19 @@
     && document.extension!='link'; else contentDiv">
       Lo sentimos. No existe una vista previa para este archivo.
     </div>
-    <ng-template #contentDiv>
-      <div *ngIf="loading" class="inner-loading-wheel">
-        <div class="loader-wheel"></div>
-      </div>
-      <div *ngIf="document.extension=='.pdf'">
-        <pdf-viewer src="{{'/api/Files/' + this.document.link}}" (after-load-complete)="loading=false">
-        </pdf-viewer>
-      </div>
-      <div *ngIf="document.extension=='.jpg' || document.extension=='.jpeg' || document.extension=='.png'">
-        <img src="{{'/api/Files/' + this.document.link}}" (load)="loading=false">
-      </div>
-      <iframe style="height:80vh; width:100%;" *ngIf="document.extension=='link'" 
-      [src]="this.document.link | safeDom" (load)="loading=false">
-      </iframe>
-    </ng-template>
   </div>
+  <ng-template #contentDiv>
+    <div *ngIf="loading" class="inner-loading-wheel">
+      <div class="loader-wheel"></div>
+    </div>
+    <div *ngIf="document.extension=='.pdf'">
+      <pdf-viewer src="{{'/api/Files/' + this.document.link}}" (after-load-complete)="loading=false">
+      </pdf-viewer>
+    </div>
+    <div *ngIf="document.extension=='.jpg' || document.extension=='.jpeg' || document.extension=='.png'">
+      <img src="{{'/api/Files/' + this.document.link}}" (load)="loading=false">
+    </div>
+    <iframe style="height:80vh; width:100%;" *ngIf="document.extension=='link'"
+            [src]="this.document.link | safeDom" (load)="loading=false"></iframe>
+  </ng-template>
+</div>

--- a/ClientApp/src/app/components/indicator-detail/indicator-detail-registry/indicator-detail-registry.component.ts
+++ b/ClientApp/src/app/components/indicator-detail/indicator-detail-registry/indicator-detail-registry.component.ts
@@ -205,7 +205,7 @@ export class IndicatorDetailRegistryComponent implements OnInit {
       type: 'warning',
       showCancelButton: true,
       confirmButtonText: 'Aceptar',
-      cancelButtonText: 'CANCELAR',
+      cancelButtonText: 'Cancelar',
       buttonsStyling: false,
       reverseButtons: true,
       confirmButtonClass: 'btn btn-sm btn-primary',

--- a/ClientApp/src/app/components/indicator-detail/indicator-detail.component.html
+++ b/ClientApp/src/app/components/indicator-detail/indicator-detail.component.html
@@ -49,12 +49,12 @@
       <ol class="breadcrumb shortcode">
         <div *ngIf="indicator.registriesType != RegistryType.ExternalRegistry">
           <button class="btn btn-xs btn-clean-2" (click)="openModal(editGoalModal)">Modificar Metas</button>
-          <button class="btn btn-xs btn-clean-2">Modificar Indicador</button>
+          <button class="btn btn-xs btn-clean-2" (click)="openModalEditIndicator(editIndicator)">Modificar Indicador</button>
         </div>
-        
+
         <div *ngIf="indicator.registriesType == RegistryType.ExternalRegistry">
             <button class="btn btn-xs btn-clean-2" (click)="openModal(editGoalModal)">Modificar Metas</button>
-        </div>        
+        </div>
       </ol>
     </div>
   </section>
@@ -192,6 +192,35 @@
   <!-- Modal Edit Goal -->
   <ng-template #editGoalModal>
     <app-goals-editor [indicator]="indicator" (updateGoalEvent)="updateGoal($event)" [modalRef]="modalRef"></app-goals-editor>
+  </ng-template>
+
+  <!-- Modal Edit Indicator -->
+  <ng-template #editIndicator>
+    <div class="modal-header" tabindex="-1">
+      <h4 class="modal-title pull-left">Modificar Indicador</h4>
+      <button type="button" class="close pull-right" aria-label="Close" (click)="indicatorModalRef.hide()">
+        <span aria-hidden="true">&times;</span>
+      </button>
+    </div>
+    <app-indicator-editor [indicatorModalRef]="indicatorModalRef" [indicator]="indicatorToEdit" (updateInfo)="updateIndicator()" ></app-indicator-editor>
+  </ng-template>
+  <!--UX-->
+
+  <ng-template #zero>
+    <div class="row-number row-h1 inline">
+      <div *ngIf="indicator.registriesType == RegistryType.PercentRegistry">
+        0%
+      </div>
+      <div *ngIf="indicator.registriesType != RegistryType.PercentRegistry">
+        0
+      </div>
+    </div>
+  </ng-template>
+
+  <ng-template #na>
+    <div class="row-number row-h1 inline">
+      N/A
+    </div>
   </ng-template>
 
 </div>

--- a/ClientApp/src/app/components/indicator-detail/indicator-detail.component.ts
+++ b/ClientApp/src/app/components/indicator-detail/indicator-detail.component.ts
@@ -245,7 +245,7 @@ export class IndicatorDetailComponent implements OnInit {
     this.sessionStorage.setMonth(this.selectedMonth);
   }
 
-  
+
   // Update the goals depending the already selected filters
   updateGoal(event) {
     if (this.selectedYear === -1) { // All years

--- a/ClientApp/src/app/components/indicator-detail/indicator-detail.component.ts
+++ b/ClientApp/src/app/components/indicator-detail/indicator-detail.component.ts
@@ -39,10 +39,12 @@ export class IndicatorDetailComponent implements OnInit {
   public idIndicator = -1;
 
   public indicator$: Observable<Indicator>;
+  public indicatorToEdit: Indicator; // For edit Modal
   public goal$: Observable<number>;
   public value$: Observable<number>;
   router: Router;
   modalRef: BsModalRef;
+  indicatorModalRef: BsModalRef;
 
   allYears: string = IndicatorDetailComponent.ALL_YEARS;
   selectedYearText: string; // Dropdown year "Año 2018"
@@ -79,6 +81,10 @@ export class IndicatorDetailComponent implements OnInit {
   ngOnInit() {
     this.indicator$ = this.service.getIndicator(this.idIndicator);
     this.updateExternalIndicator();
+
+    this.indicator$.subscribe(data =>{ // Just to preload the data, I don't like to do this, but it is what it is
+      this.indicatorToEdit = data;
+    });
 
     const currentYear = new Date().getFullYear();
     const baseYear = 2018;
@@ -184,6 +190,10 @@ export class IndicatorDetailComponent implements OnInit {
     this.modalRef = this.modalService.show(template);
   }
 
+  openModalEditIndicator(template: TemplateRef<any>) {
+    this.indicatorModalRef = this.modalService.show(template);
+  }
+
   selectChart(type: string, indicator: Indicator) {
 
 
@@ -262,6 +272,13 @@ export class IndicatorDetailComponent implements OnInit {
       if (indicator.registriesType === RegistryType.ExternalRegistry) {
         this.registryService.getRegistriesExternal().subscribe();
       }
+    });
+  }
+
+  updateIndicator() {
+    this.indicator$ = this.service.getIndicator(this.idIndicator);
+    this.indicator$.subscribe(data =>{ // Just to preload the data, I don't like to do this, but it is what it is
+      this.indicatorToEdit = data;
     });
   }
 

--- a/ClientApp/src/app/components/indicator-detail/indicator-editor/indicator-editor.component.css
+++ b/ClientApp/src/app/components/indicator-detail/indicator-editor/indicator-editor.component.css
@@ -1,0 +1,7 @@
+.ng-valid[required], .ng-valid.required {
+  border-left: 5px solid #5cb85c; /* green */
+}
+
+.ng-invalid:not(form) {
+  border-left: 5px solid #d9534f; /* red */
+}

--- a/ClientApp/src/app/components/indicator-detail/indicator-editor/indicator-editor.component.html
+++ b/ClientApp/src/app/components/indicator-detail/indicator-editor/indicator-editor.component.html
@@ -1,0 +1,41 @@
+<form #editIndicatorForm="ngForm" (ngSubmit)="onSubmit()">
+  <div class="modal-body">
+    <div class="row">
+      <div class="col-xs-12 col-sm-12 col-md-12">
+        <h4 class="head-project-title">Información Básica</h4>
+      </div>
+    </div>
+    <div class="row">
+      <div class="form-group col-sm-12 col-md-12">
+        <label>Nombre del indicador</label>
+        <input type="text"  class="form-control" id="name" required [(ngModel)]="newIndicator.name" name="name" #name="ngModel" />
+        <div [hidden]="name.valid || name.pristine"
+             class="alert alert-danger">
+          Nombre no puede estar vacio
+        </div>
+      </div>
+    </div>
+    <div class="row">
+      <div class="form-group col-sm-6 col-md-6"> <!-- Enough space just to show the label on the "first line". So, the dropdown will be on the "second line"-->
+        <label>Resultado esperado al que pertenece</label>
+        <div class="btn-group" dropdown>
+          <button id="button-basic" dropdownToggle type="button" class="btn-drop btn btn-sm btn-primary dropdown-toggle" aria-controls="dropdown-basic">
+            {{(selectedText.length&gt;maxLength? (selectedText | slice:0:maxLength)+&apos;..&apos;:(selectedText))}}
+            <span class="caret"></span>
+          </button>
+          <ul id="dropdown-basic" *dropdownMenu class="dropdown-menu"
+              role="menu" aria-labelledby="button-basic">
+            <li *ngFor="let group of groups"><a class="dropdown-item" (click)="updateSelected(group.name)">{{(group.name.length&gt;(maxLength+10)? (group.name | slice:0:(maxLength+10))+&apos;..&apos;:(group.name))}}</a></li>
+          </ul>
+        </div>
+      </div>
+    </div>
+
+
+
+  </div>
+  <div class="modal-footer"> <!--modal-footer needed, in other case, the button will be outside the modal-->
+    <button type="button" (click)="indicatorModalRef.hide()" class="btn btn-sm btn-clean-2" ng-click=cancel()>Cancelar</button>
+    <button type="submit" class="btn btn-sm btn-primary" [disabled]="!editIndicatorForm.form.valid">Aceptar</button>
+  </div>
+</form>

--- a/ClientApp/src/app/components/indicator-detail/indicator-editor/indicator-editor.component.spec.ts
+++ b/ClientApp/src/app/components/indicator-detail/indicator-editor/indicator-editor.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { IndicatorEditorComponent } from './indicator-editor.component';
+
+describe('IndicatorEditorComponent', () => {
+  let component: IndicatorEditorComponent;
+  let fixture: ComponentFixture<IndicatorEditorComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ IndicatorEditorComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(IndicatorEditorComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/ClientApp/src/app/components/indicator-detail/indicator-editor/indicator-editor.component.ts
+++ b/ClientApp/src/app/components/indicator-detail/indicator-editor/indicator-editor.component.ts
@@ -1,0 +1,100 @@
+import {Component, OnInit, Input, Output, EventEmitter} from '@angular/core';
+import {Router} from '@angular/router';
+
+import { BsModalRef } from 'ngx-bootstrap/modal';
+
+// Models
+import { Indicator } from '../../../shared/models/indicator';
+import { IndicatorGroup} from '../../../shared/models/indicatorGroup';
+// Services
+import { IndicatorGroupService } from '../../../services/indicator-group/indicator-group.service';
+import { IndicatorService } from '../../../services/indicator/indicator.service';
+
+import swal from 'sweetalert2';
+
+@Component({
+  selector: 'app-indicator-editor',
+  templateUrl: './indicator-editor.component.html',
+  styleUrls: ['./indicator-editor.component.css']
+})
+export class IndicatorEditorComponent implements OnInit {
+
+  @Input()
+  public indicatorModalRef: BsModalRef;
+
+  @Input()
+  public indicator: Indicator;
+
+  @Output()
+  updateInfo = new EventEmitter();
+
+  public newIndicator: Indicator;
+  public groups: IndicatorGroup[];
+
+  public selectedText = 'Cambiar el resultado esperado al que pertenece';
+  public maxLength = 46; // The selectedText gets truncated on maxLength characters
+                        // The indicatorGroup name show a few more characters
+                        // Why 46? - Count the characters of selectedText
+
+  constructor(private service: IndicatorService,
+              private indicatorGroupService: IndicatorGroupService,
+              private router: Router) { }
+
+  ngOnInit() {
+    this.newIndicator = JSON.parse(JSON.stringify(this.indicator)); // Create a clone of the original Indicator.
+    const groupId = this.indicator.indicatorGroupID;
+
+    this.indicatorGroupService.getIndicatorGroups().subscribe(data => {
+      this.groups = data;
+    });
+
+
+  }
+
+  updateSelected(value: string) {
+    this.selectedText = value;
+  }
+
+  onSubmit() {
+    let moved = false;
+    for (let ig of this.groups) {
+      if (ig.name === this.selectedText) {
+        if (ig.indicatorGroupID !== this.newIndicator.indicatorGroupID) { // Moved to another IndicatorGroup
+          moved = true;
+        }
+        this.newIndicator.indicatorGroupID = ig.indicatorGroupID;
+
+      }
+    }
+
+    this.service.editIndicator(this.newIndicator).subscribe(data => {
+      if (data) {
+        if (moved) {
+          this.router.navigateByUrl('/indicatorGroup/' + this.newIndicator.indicatorGroupID );
+        } else {
+          this.updateInfo.emit('Indicator updated');
+          // this.router.navigateByUrl('/indicatorGroup/' + this.newIndicator.indicatorGroupID ); // I'll find a better way
+        }
+      } else {
+        this.duplicateNameAlert();
+      }
+
+
+    });
+    this.indicatorModalRef.hide();
+  }
+
+  private duplicateNameAlert() {
+    swal({
+      title: 'Error al editar el indicador',
+      html: '<h6> Ya existe un indicador con el nombre "' + this.newIndicator.name + '"</h6>',
+      type: 'warning',
+      confirmButtonText: 'Aceptar',
+      buttonsStyling: false,
+      confirmButtonClass: 'btn btn-sm btn-primary',
+      allowOutsideClick: false,
+      allowEscapeKey: false
+    });
+  }
+
+}

--- a/ClientApp/src/app/components/indicator-home/indicator-form/indicator-form.component.css
+++ b/ClientApp/src/app/components/indicator-home/indicator-form/indicator-form.component.css
@@ -5,3 +5,11 @@
 .ng-invalid:not(form) {
   border-left: 5px solid #d9534f; /* red */
 }
+
+.table td {
+  text-align: center;
+}
+
+.table {
+  margin: 5px;
+}

--- a/ClientApp/src/app/components/indicator-home/indicator-form/indicator-form.component.html
+++ b/ClientApp/src/app/components/indicator-home/indicator-form/indicator-form.component.html
@@ -52,7 +52,7 @@
                   #registriesDescription="ngModel"></textarea>
       </div>
     </div>
-
+    <div class="row"><label>Administración de permisos</label></div>
     <div class="row">
       <table class="table table-condensed">
         <thead>
@@ -65,53 +65,53 @@
         <tbody>
         <tr>
           <th>Administrador</th>
-          <td><input class="form-check-input" type="checkbox" value="" id="check1" [(ngModel)]="write.adm" name="write1"></td>
-          <td><input class="form-check-input" type="checkbox" value="" id="check2" [(ngModel)]="read.adc" name="read1"></td>
+          <td><input class="form-check-input" type="checkbox" value="" id="check1" [(ngModel)]="read.adm" name="read1"></td>
+          <td><input class="form-check-input" type="checkbox" value="" id="check2" [(ngModel)]="write.adm" name="write1"></td>
         </tr>
         <tr>
           <th>Gerencia y dirección	</th>
-          <td><input class="form-check-input" type="checkbox" value="" id="check3" [(ngModel)]="write.ger" name="write2"></td>
-          <td><input class="form-check-input" type="checkbox" value="" id="check4" [(ngModel)]="read.ger" name="read2"></td>
+          <td><input class="form-check-input" type="checkbox" value="" id="check3" [(ngModel)]="read.ger" name="read2"></td>
+          <td><input class="form-check-input" type="checkbox" value="" id="check4" [(ngModel)]="write.ger" name="read"></td>
         </tr>
         <tr>
           <th>Encargado de operaciones	</th>
-          <td><input class="form-check-input" type="checkbox" value="" id="check5" [(ngModel)]="write.enOp" name="write3"></td>
-          <td><input class="form-check-input" type="checkbox" value="" id="check6" [(ngModel)]="read.encOp" name="read3"></td>
+          <td><input class="form-check-input" type="checkbox" value="" id="check5" [(ngModel)]="read.enOp" name="read3"></td>
+          <td><input class="form-check-input" type="checkbox" value="" id="check6" [(ngModel)]="write.encOp" name="write3"></td>
         </tr>
         <tr>
           <th>Analista de operaciones	</th>
-          <td><input class="form-check-input" type="checkbox" value="" id="check7" [(ngModel)]="write.anOp" name="write4"></td>
-          <td><input class="form-check-input" type="checkbox" value="" id="check8" [(ngModel)]="read.anOp" name="read4"></td>
+          <td><input class="form-check-input" type="checkbox" value="" id="check7" [(ngModel)]="read.anOp" name="read4"></td>
+          <td><input class="form-check-input" type="checkbox" value="" id="check8" [(ngModel)]="write.anOp" name="write4"></td>
         </tr>
         <tr>
           <th>Ejecutivo de post-venta	</th>
-          <td><input class="form-check-input" type="checkbox" value="" id="check9" [(ngModel)]="write.ejVta" name="write5"></td>
-          <td><input class="form-check-input" type="checkbox" value="" id="check10" [(ngModel)]="read.ejVta" name="read5"></td>
+          <td><input class="form-check-input" type="checkbox" value="" id="check9" [(ngModel)]="read.ejVta" name="read5"></td>
+          <td><input class="form-check-input" type="checkbox" value="" id="check10" [(ngModel)]="write.ejVta" name="write5"></td>
         </tr>
         <tr>
           <th>Encargada de nuevos negocios	</th>
-          <td><input class="form-check-input" type="checkbox" value="" id="check11" [(ngModel)]="write.nvoNeg" name="write6"></td>
-          <td><input class="form-check-input" type="checkbox" value="" id="check12" [(ngModel)]="read.nvoNeg" name="read6"></td>
+          <td><input class="form-check-input" type="checkbox" value="" id="check11" [(ngModel)]="read.nvoNeg" name="read6"></td>
+          <td><input class="form-check-input" type="checkbox" value="" id="check12" [(ngModel)]="write.nvoNeg" name="write6"></td>
         </tr>
         <tr>
           <th>Ejecutiva técnica de control y seguimiento	</th>
-          <td><input class="form-check-input" type="checkbox" value="" id="check13" [(ngModel)]="write.ctrlSeg" name="write7"></td>
-          <td><input class="form-check-input" type="checkbox" value="" id="check14" [(ngModel)]="read.ctrlSeg" name="read7"></td>
+          <td><input class="form-check-input" type="checkbox" value="" id="check13" [(ngModel)]="read.ctrlSeg" name="read7"></td>
+          <td><input class="form-check-input" type="checkbox" value="" id="check14" [(ngModel)]="write.ctrlSeg" name="write7"></td>
         </tr>
         <tr>
           <th>Extensionista senior	</th>
-          <td><input class="form-check-input" type="checkbox" value="" id="check15" [(ngModel)]="write.exSr" name="write8"></td>
-          <td><input class="form-check-input" type="checkbox" value="" id="check16" [(ngModel)]="read.exSr" name="read8"></td>
+          <td><input class="form-check-input" type="checkbox" value="" id="check15" [(ngModel)]="read.exSr" name="read8"></td>
+          <td><input class="form-check-input" type="checkbox" value="" id="check16" [(ngModel)]="write.exSr" name="write8"></td>
         </tr>
         <tr>
           <th>Extensionista junior	</th>
-          <td><input class="form-check-input" type="checkbox" value="" id="check17" [(ngModel)]="write.exJr" name="write9"></td>
-          <td><input class="form-check-input" type="checkbox" value="" id="check18" [(ngModel)]="read.exJr" name="write9"></td>
+          <td><input class="form-check-input" type="checkbox" value="" id="check17" [(ngModel)]="read.exJr" name="read9"></td>
+          <td><input class="form-check-input" type="checkbox" value="" id="check18" [(ngModel)]="write.exJr" name="read9"></td>
         </tr>
         <tr>
           <th>Periodista</th>
-          <td><input class="form-check-input" type="checkbox" value="" id="check19" [(ngModel)]="write.prdta" name="write10"></td>
-          <td><input class="form-check-input" type="checkbox" value="" id="check20" [(ngModel)]="read.prdta" name="read10"></td>
+          <td><input class="form-check-input" type="checkbox" value="" id="check19" [(ngModel)]="read.prdta" name="read10"></td>
+          <td><input class="form-check-input" type="checkbox" value="" id="check20" [(ngModel)]="write.prdta" name="write10"></td>
         </tr>
         </tbody>
 

--- a/ClientApp/src/app/components/indicator-home/indicator-form/indicator-form.component.html
+++ b/ClientApp/src/app/components/indicator-home/indicator-form/indicator-form.component.html
@@ -66,52 +66,52 @@
         <tr>
           <th>Administrador</th>
           <td><input class="form-check-input" type="checkbox" value="" id="check1" [(ngModel)]="read.adm" name="read1"></td>
-          <td><input class="form-check-input" type="checkbox" value="" id="check2" [(ngModel)]="write.adm" name="write1"></td>
+          <td><input class="form-check-input" type="checkbox" value="" id="check2" [(ngModel)]="write.adm" name="write1" [disabled]="!read.adm"></td>
         </tr>
         <tr>
           <th>Gerencia y dirección	</th>
           <td><input class="form-check-input" type="checkbox" value="" id="check3" [(ngModel)]="read.ger" name="read2"></td>
-          <td><input class="form-check-input" type="checkbox" value="" id="check4" [(ngModel)]="write.ger" name="read"></td>
+          <td><input class="form-check-input" type="checkbox" value="" id="check4" [(ngModel)]="write.ger" name="read" [disabled]="!read.ger"></td>
         </tr>
         <tr>
           <th>Encargado de operaciones	</th>
           <td><input class="form-check-input" type="checkbox" value="" id="check5" [(ngModel)]="read.enOp" name="read3"></td>
-          <td><input class="form-check-input" type="checkbox" value="" id="check6" [(ngModel)]="write.encOp" name="write3"></td>
+          <td><input class="form-check-input" type="checkbox" value="" id="check6" [(ngModel)]="write.encOp" name="write3" [disabled]="!read.enOp"></td>
         </tr>
         <tr>
           <th>Analista de operaciones	</th>
           <td><input class="form-check-input" type="checkbox" value="" id="check7" [(ngModel)]="read.anOp" name="read4"></td>
-          <td><input class="form-check-input" type="checkbox" value="" id="check8" [(ngModel)]="write.anOp" name="write4"></td>
+          <td><input class="form-check-input" type="checkbox" value="" id="check8" [(ngModel)]="write.anOp" name="write4" [disabled]="!read.anOp"></td>
         </tr>
         <tr>
           <th>Ejecutivo de post-venta	</th>
           <td><input class="form-check-input" type="checkbox" value="" id="check9" [(ngModel)]="read.ejVta" name="read5"></td>
-          <td><input class="form-check-input" type="checkbox" value="" id="check10" [(ngModel)]="write.ejVta" name="write5"></td>
+          <td><input class="form-check-input" type="checkbox" value="" id="check10" [(ngModel)]="write.ejVta" name="write5" [disabled]="!read.ejVta"></td>
         </tr>
         <tr>
           <th>Encargada de nuevos negocios	</th>
           <td><input class="form-check-input" type="checkbox" value="" id="check11" [(ngModel)]="read.nvoNeg" name="read6"></td>
-          <td><input class="form-check-input" type="checkbox" value="" id="check12" [(ngModel)]="write.nvoNeg" name="write6"></td>
+          <td><input class="form-check-input" type="checkbox" value="" id="check12" [(ngModel)]="write.nvoNeg" name="write6" [disabled]="!read.nvoNeg"></td>
         </tr>
         <tr>
           <th>Ejecutiva técnica de control y seguimiento	</th>
           <td><input class="form-check-input" type="checkbox" value="" id="check13" [(ngModel)]="read.ctrlSeg" name="read7"></td>
-          <td><input class="form-check-input" type="checkbox" value="" id="check14" [(ngModel)]="write.ctrlSeg" name="write7"></td>
+          <td><input class="form-check-input" type="checkbox" value="" id="check14" [(ngModel)]="write.ctrlSeg" name="write7" [disabled]="!read.ctrlSeg"></td>
         </tr>
         <tr>
           <th>Extensionista senior	</th>
           <td><input class="form-check-input" type="checkbox" value="" id="check15" [(ngModel)]="read.exSr" name="read8"></td>
-          <td><input class="form-check-input" type="checkbox" value="" id="check16" [(ngModel)]="write.exSr" name="write8"></td>
+          <td><input class="form-check-input" type="checkbox" value="" id="check16" [(ngModel)]="write.exSr" name="write8" [disabled]="!read.exSr"></td>
         </tr>
         <tr>
           <th>Extensionista junior	</th>
           <td><input class="form-check-input" type="checkbox" value="" id="check17" [(ngModel)]="read.exJr" name="read9"></td>
-          <td><input class="form-check-input" type="checkbox" value="" id="check18" [(ngModel)]="write.exJr" name="read9"></td>
+          <td><input class="form-check-input" type="checkbox" value="" id="check18" [(ngModel)]="write.exJr" name="write9" [disabled]="!read.exJr"></td>
         </tr>
         <tr>
           <th>Periodista</th>
           <td><input class="form-check-input" type="checkbox" value="" id="check19" [(ngModel)]="read.prdta" name="read10"></td>
-          <td><input class="form-check-input" type="checkbox" value="" id="check20" [(ngModel)]="write.prdta" name="write10"></td>
+          <td><input class="form-check-input" type="checkbox" value="" id="check20" [(ngModel)]="write.prdta" name="write10" [disabled]="!read.prdta"></td>
         </tr>
         </tbody>
 

--- a/ClientApp/src/app/components/indicator-home/indicator-form/indicator-form.component.html
+++ b/ClientApp/src/app/components/indicator-home/indicator-form/indicator-form.component.html
@@ -65,23 +65,23 @@
         <tbody>
         <tr>
           <th>Administrador</th>
-          <td><input class="form-check-input" type="checkbox" value="" id="check1" [(ngModel)]="read.adm" name="read1"></td>
-          <td><input class="form-check-input" type="checkbox" value="" id="check2" [(ngModel)]="write.adm" name="write1" [disabled]="!read.adm"></td>
+          <td><input class="form-check-input" type="checkbox" value="" id="check1" [(ngModel)]="read.adm" name="read1" disabled></td>
+          <td><input class="form-check-input" type="checkbox" value="" id="check2" [(ngModel)]="write.adm" name="write1" disabled></td>
         </tr>
         <tr>
           <th>Gerencia y dirección	</th>
-          <td><input class="form-check-input" type="checkbox" value="" id="check3" [(ngModel)]="read.ger" name="read2"></td>
+          <td><input class="form-check-input" type="checkbox" value="" id="check3" [(ngModel)]="read.ger" name="read2" disabled></td>
           <td><input class="form-check-input" type="checkbox" value="" id="check4" [(ngModel)]="write.ger" name="read" [disabled]="!read.ger"></td>
         </tr>
         <tr>
           <th>Encargado de operaciones	</th>
-          <td><input class="form-check-input" type="checkbox" value="" id="check5" [(ngModel)]="read.enOp" name="read3"></td>
-          <td><input class="form-check-input" type="checkbox" value="" id="check6" [(ngModel)]="write.encOp" name="write3" [disabled]="!read.enOp"></td>
+          <td><input class="form-check-input" type="checkbox" value="" id="check5" [(ngModel)]="read.encOp" name="read3" disabled></td>
+          <td><input class="form-check-input" type="checkbox" value="" id="check6" [(ngModel)]="write.encOp" name="write3" [disabled]="!read.encOp"></td>
         </tr>
         <tr>
           <th>Analista de operaciones	</th>
-          <td><input class="form-check-input" type="checkbox" value="" id="check7" [(ngModel)]="read.anOp" name="read4"></td>
-          <td><input class="form-check-input" type="checkbox" value="" id="check8" [(ngModel)]="write.anOp" name="write4" [disabled]="!read.anOp"></td>
+          <td><input class="form-check-input" type="checkbox" value="" id="check7" [(ngModel)]="read.anOp" name="read4" disabled></td>
+          <td><input class="form-check-input" type="checkbox" value="" id="check8" [(ngModel)]="write.anOp" name="write4" disabled></td>
         </tr>
         <tr>
           <th>Ejecutivo de post-venta	</th>
@@ -90,8 +90,8 @@
         </tr>
         <tr>
           <th>Encargada de nuevos negocios	</th>
-          <td><input class="form-check-input" type="checkbox" value="" id="check11" [(ngModel)]="read.nvoNeg" name="read6"></td>
-          <td><input class="form-check-input" type="checkbox" value="" id="check12" [(ngModel)]="write.nvoNeg" name="write6" [disabled]="!read.nvoNeg"></td>
+          <td><input class="form-check-input" type="checkbox" value="" id="check11" [(ngModel)]="read.nvoNeg" name="read6" disabled></td>
+          <td><input class="form-check-input" type="checkbox" value="" id="check12" [(ngModel)]="write.nvoNeg" name="write6" disabled></td>
         </tr>
         <tr>
           <th>Ejecutiva técnica de control y seguimiento	</th>

--- a/ClientApp/src/app/components/indicator-home/indicator-form/indicator-form.component.html
+++ b/ClientApp/src/app/components/indicator-home/indicator-form/indicator-form.component.html
@@ -3,7 +3,8 @@
     <div class="row">
       <div class="form-group col-xs-12 col-sm-12 col-md-12">
         <label>Nombre</label>
-        <input type="text" placeholder="Nombre" class="form-control" id="name" required [(ngModel)]="model.name" name="name" #name="ngModel" />
+        <input type="text" placeholder="Nombre" class="form-control" id="name" required [(ngModel)]="model.name"
+               name="name" #name="ngModel"/>
         <div [hidden]="name.valid || name.pristine"
              class="alert alert-danger">
           Nombre no puede estar vacio
@@ -14,33 +15,109 @@
       <div class="form-group col-xs-12 col-sm-4 col-md-5">
         <label>Tipo de registros</label>
         <div class="btn-group" dropdown>
-          <button id="button-basic" dropdownToggle type="button" class="btn btn-sm btn-primary dropdown-toggle" aria-controls="dropdown-basic">
+          <button id="button-basic" dropdownToggle type="button" class="btn btn-sm btn-primary dropdown-toggle"
+                  aria-controls="dropdown-basic">
             {{ selectedIndicatorTypeText }}
             <span class="caret"></span>
           </button>
           <ul id="dropdown-basic" *dropdownMenu class="dropdown-menu"
-            role="menu" aria-labelledby="button-basic">
+              role="menu" aria-labelledby="button-basic">
             <li *ngFor="let type of types"><a class="dropdown-item" (click)="updateDropdown(type)">{{ type }}</a></li>
           </ul>
         </div>
       </div>
-      <div class="form-group col-xs-12 col-sm-12 col-md-5 col-md-offset-2" *ngIf="selectedIndicatorTypeText == types[1] || selectedIndicatorTypeText == types[2]">
-        <label *ngIf="selectedIndicatorTypeText == types[1]">Nombre de registros <a popover="Nombre de los registros (ej. Empresas, Entidades, Asistentes, etc.)" triggers="mouseenter:mouseleave">(?)</a></label>
-        <label *ngIf="selectedIndicatorTypeText == types[2]">Nombre del porcentaje <a popover="¿Qué representa el porcentaje?(ej. % de satisfacción)" triggers="mouseenter:mouseleave">(?)</a></label>
-        <input type="text" class="form-control" id="registriesName" required [(ngModel)]="model.registriesName" name="registriesName" #registriesName="ngModel" />
+      <div class="form-group col-xs-12 col-sm-12 col-md-5 col-md-offset-2"
+           *ngIf="selectedIndicatorTypeText == types[1] || selectedIndicatorTypeText == types[2]">
+        <label *ngIf="selectedIndicatorTypeText == types[1]">Nombre de registros <a
+          popover="Nombre de los registros (ej. Empresas, Entidades, Asistentes, etc.)"
+          triggers="mouseenter:mouseleave">(?)</a></label>
+        <label *ngIf="selectedIndicatorTypeText == types[2]">Nombre del porcentaje <a
+          popover="¿Qué representa el porcentaje?(ej. % de satisfacción)"
+          triggers="mouseenter:mouseleave">(?)</a></label>
+        <input type="text" class="form-control" id="registriesName" required [(ngModel)]="model.registriesName"
+               name="registriesName" #registriesName="ngModel"/>
         <div [hidden]="(registriesName.valid || registriesName.pristine)"
              class="alert alert-danger">
           No puede esta vacio
         </div>
       </div>
     </div>
+
+
+
     <div class="row">
       <div class="form-group col-xs-12 col-sm-12 col-md-12">
         <label>Descripción de los registros</label>
-        <textarea class="form-control" rows="3" [(ngModel)]="model.registriesDescription" name="registriesDescription" #registriesDescription="ngModel"></textarea>
+        <textarea class="form-control" rows="3" [(ngModel)]="model.registriesDescription" name="registriesDescription"
+                  #registriesDescription="ngModel"></textarea>
       </div>
-
     </div>
+
+    <div class="row">
+      <table class="table table-condensed">
+        <thead>
+        <tr>
+          <th>Rol</th>
+          <td>Lectura</td>
+          <td>Escritura</td>
+        </tr>
+        </thead>
+        <tbody>
+        <tr>
+          <th>Administrador</th>
+          <td><input class="form-check-input" type="checkbox" value="" id="check1" [(ngModel)]="write.adm" name="write1"></td>
+          <td><input class="form-check-input" type="checkbox" value="" id="check2" [(ngModel)]="read.adc" name="read1"></td>
+        </tr>
+        <tr>
+          <th>Gerencia y dirección	</th>
+          <td><input class="form-check-input" type="checkbox" value="" id="check3" [(ngModel)]="write.ger" name="write2"></td>
+          <td><input class="form-check-input" type="checkbox" value="" id="check4" [(ngModel)]="read.ger" name="read2"></td>
+        </tr>
+        <tr>
+          <th>Encargado de operaciones	</th>
+          <td><input class="form-check-input" type="checkbox" value="" id="check5" [(ngModel)]="write.enOp" name="write3"></td>
+          <td><input class="form-check-input" type="checkbox" value="" id="check6" [(ngModel)]="read.encOp" name="read3"></td>
+        </tr>
+        <tr>
+          <th>Analista de operaciones	</th>
+          <td><input class="form-check-input" type="checkbox" value="" id="check7" [(ngModel)]="write.anOp" name="write4"></td>
+          <td><input class="form-check-input" type="checkbox" value="" id="check8" [(ngModel)]="read.anOp" name="read4"></td>
+        </tr>
+        <tr>
+          <th>Ejecutivo de post-venta	</th>
+          <td><input class="form-check-input" type="checkbox" value="" id="check9" [(ngModel)]="write.ejVta" name="write5"></td>
+          <td><input class="form-check-input" type="checkbox" value="" id="check10" [(ngModel)]="read.ejVta" name="read5"></td>
+        </tr>
+        <tr>
+          <th>Encargada de nuevos negocios	</th>
+          <td><input class="form-check-input" type="checkbox" value="" id="check11" [(ngModel)]="write.nvoNeg" name="write6"></td>
+          <td><input class="form-check-input" type="checkbox" value="" id="check12" [(ngModel)]="read.nvoNeg" name="read6"></td>
+        </tr>
+        <tr>
+          <th>Ejecutiva técnica de control y seguimiento	</th>
+          <td><input class="form-check-input" type="checkbox" value="" id="check13" [(ngModel)]="write.ctrlSeg" name="write7"></td>
+          <td><input class="form-check-input" type="checkbox" value="" id="check14" [(ngModel)]="read.ctrlSeg" name="read7"></td>
+        </tr>
+        <tr>
+          <th>Extensionista senior	</th>
+          <td><input class="form-check-input" type="checkbox" value="" id="check15" [(ngModel)]="write.exSr" name="write8"></td>
+          <td><input class="form-check-input" type="checkbox" value="" id="check16" [(ngModel)]="read.exSr" name="read8"></td>
+        </tr>
+        <tr>
+          <th>Extensionista junior	</th>
+          <td><input class="form-check-input" type="checkbox" value="" id="check17" [(ngModel)]="write.exJr" name="write9"></td>
+          <td><input class="form-check-input" type="checkbox" value="" id="check18" [(ngModel)]="read.exJr" name="write9"></td>
+        </tr>
+        <tr>
+          <th>Periodista</th>
+          <td><input class="form-check-input" type="checkbox" value="" id="check19" [(ngModel)]="write.prdta" name="write10"></td>
+          <td><input class="form-check-input" type="checkbox" value="" id="check20" [(ngModel)]="read.prdta" name="read10"></td>
+        </tr>
+        </tbody>
+
+      </table>
+    </div>
+
   </div>
   <div class="modal-footer">
     <!--modal-footer needed, in other case, the button will be outside the modal-->

--- a/ClientApp/src/app/components/indicator-home/indicator-form/indicator-form.component.ts
+++ b/ClientApp/src/app/components/indicator-home/indicator-form/indicator-form.component.ts
@@ -81,15 +81,11 @@ export class IndicatorFormComponent implements OnInit {
           for (let i in this.read) {
             if (this.read[i] === true) {
               this.roleService.addPermissionRead(RolesType[i], (data as Indicator)).subscribe();
+              if (this.write[i] === true) { // read and/or write permissions
+                this.roleService.addPermissionWrite(RolesType[i], (data as Indicator)).subscribe();
+              }
             }
           }
-
-          for (let i in this.write) {
-            if (this.write[i] === true) {
-              this.roleService.addPermissionWrite(RolesType[i], (data as Indicator)).subscribe();
-            }
-          }
-
           this.udpateEvent.emit("Indicator Added");
         }
       }

--- a/ClientApp/src/app/components/indicator-home/indicator-form/indicator-form.component.ts
+++ b/ClientApp/src/app/components/indicator-home/indicator-form/indicator-form.component.ts
@@ -3,10 +3,12 @@ import {BsModalRef, BsModalService} from "ngx-bootstrap";
 
 // Models
 import { Indicator } from '../../../shared/models/indicator';
-import {RegistryType} from "../../../shared/models/registryType";
+import {RegistryType} from '../../../shared/models/registryType';
+import { RolesType } from '../../../shared/models/rolesType';
 
 // Services
-import { IndicatorService} from "../../../services/indicator/indicator.service";
+import { IndicatorService} from '../../../services/indicator/indicator.service';
+import { RoleService } from '../../../services/role/role.service';
 
 import swal from 'sweetalert2';
 
@@ -29,9 +31,16 @@ export class IndicatorFormComponent implements OnInit {
 
   public types;
 
+  // If you don't like those names, change them yourself
+  read: any = { adm: false, ger: false, encOp: false, anOp: false,
+    ejVta: false, nvoNeg: false, ctrlSeg: false, exSr: false, exJr: false, prdta: false};
+
+  write: any = { adm: false, ger: false, encOp: false, anOp: false,
+    ejVta: false, nvoNeg: false, ctrlSeg: false, exSr: false, exJr: false, prdta: false};
 
   constructor(private modalService: BsModalService,
-              private service: IndicatorService) { }
+              private service: IndicatorService,
+              private roleService: RoleService) { }
 
   ngOnInit() {
     this.types = ["Registros simples",
@@ -69,6 +78,14 @@ export class IndicatorFormComponent implements OnInit {
           return;
         }
         else {
+
+          var roles_id = Object.values(RolesType); // list of 751381e9-91db-404c-94bb-dbb460551bda
+          for (let i in this.read) {
+            if (this.read[i]) {
+              console.log(RolesType[roles_id[i]]);
+            }
+          }
+
           this.udpateEvent.emit("Indicator Added");
         }
       }

--- a/ClientApp/src/app/components/indicator-home/indicator-form/indicator-form.component.ts
+++ b/ClientApp/src/app/components/indicator-home/indicator-form/indicator-form.component.ts
@@ -32,7 +32,11 @@ export class IndicatorFormComponent implements OnInit {
   public types;
 
   // If you don't like those names, change them yourself
-  read: any = { adm: true, ger: false, encOp: false, anOp: false,
+  // adm always can read or write
+  // ger always can read
+  // encOp always can read and can write, but not every indicator
+  // anOp always can read, but can't write by default
+  read: any = { adm: true, ger: true, encOp: true, anOp: true,
     ejVta: false, nvoNeg: false, ctrlSeg: false, exSr: false, exJr: false, prdta: false};
 
   write: any = { adm: true, ger: false, encOp: false, anOp: false,

--- a/ClientApp/src/app/components/indicator-home/indicator-form/indicator-form.component.ts
+++ b/ClientApp/src/app/components/indicator-home/indicator-form/indicator-form.component.ts
@@ -32,10 +32,10 @@ export class IndicatorFormComponent implements OnInit {
   public types;
 
   // If you don't like those names, change them yourself
-  read: any = { adm: false, ger: false, encOp: false, anOp: false,
+  read: any = { adm: true, ger: false, encOp: false, anOp: false,
     ejVta: false, nvoNeg: false, ctrlSeg: false, exSr: false, exJr: false, prdta: false};
 
-  write: any = { adm: false, ger: false, encOp: false, anOp: false,
+  write: any = { adm: true, ger: false, encOp: false, anOp: false,
     ejVta: false, nvoNeg: false, ctrlSeg: false, exSr: false, exJr: false, prdta: false};
 
   constructor(private modalService: BsModalService,
@@ -78,11 +78,15 @@ export class IndicatorFormComponent implements OnInit {
           return;
         }
         else {
-
-          var roles_id = Object.values(RolesType); // list of 751381e9-91db-404c-94bb-dbb460551bda
           for (let i in this.read) {
-            if (this.read[i]) {
-              console.log(RolesType[roles_id[i]]);
+            if (this.read[i] === true) {
+              this.roleService.addPermissionRead(RolesType[i], (data as Indicator)).subscribe();
+            }
+          }
+
+          for (let i in this.write) {
+            if (this.write[i] === true) {
+              this.roleService.addPermissionWrite(RolesType[i], (data as Indicator)).subscribe();
             }
           }
 

--- a/ClientApp/src/app/services/auth/AuthService.ts
+++ b/ClientApp/src/app/services/auth/AuthService.ts
@@ -7,6 +7,8 @@ import { Router } from '@angular/router';
 import { NotificationService } from '../alerts/notification.service';
 import { PermissionTarget, PermissionClaim } from './permissions';
 import { User } from './User';
+import { Role } from '../../shared/models/role';
+
 export interface Credentials {
   email: string;
   password: string;
@@ -17,7 +19,9 @@ export class AuthService {
   constructor(private http: HttpClient, private router: Router, private notifications: NotificationService) {}
 
   private static AUTHORIZATION_API = '/api/auth/';
+  private static ROLE_API = '/api/Roles/'
   private self_token = null;
+  private role: Role;
 
   public auth(credentials: Credentials): Observable<boolean> {
     return Observable.create(observer => {
@@ -31,6 +35,9 @@ export class AuthService {
           this.router.navigate(['/home']);
           this.notifications.showToaster('Sesión iniciada', 'success');
           this.self_token = this.getToken();
+          this.loadRole();
+
+
         },
         error => {
           // error path
@@ -45,6 +52,16 @@ export class AuthService {
     });
   }
 
+  private loadRole()
+  {
+    let reads: Indicator[];
+    // Load Role
+    this.http.get<Role>(AuthService.ROLE_API + (this.getUser() as User).role_ids).subscribe(data => {
+      this.role = data;
+    });
+  }
+
+  /*
   // came with this idea while listening https://www.youtube.com/watch?v=4NrJ1C4sKr8 and drinking some vodka <3
   public isAllowedTo(target: PermissionTarget, claim: PermissionClaim): boolean {
     const token = <any>this.getToken();
@@ -55,6 +72,27 @@ export class AuthService {
     }
     return false;
   }
+  */
+
+  // came with this idea while sober <3
+  public isAllowedTo(indicatorId: number, claim: PermissionClaim): boolean {
+    if (claim === PermissionClaim.WRITE) {
+      for (let indicator of  this.role.permissionsWrite) {
+        if (indicator.indicatorID === indicatorId) {
+          return true;
+        }
+      }
+      return false;
+    } else {
+      for(let indicator of this.role.permissionsRead) {
+        if (indicator.indicatorID === indicatorId) {
+          return true;
+        }
+      }
+      return false;
+    }
+  }
+
 
   public signOut() {
     return Observable.create(observer => {
@@ -63,6 +101,7 @@ export class AuthService {
       observer.complete();
       this.notifications.showToaster('Sesión finalizada', 'info');
       this.self_token = null;
+      this.role = null;
     });
   }
 

--- a/ClientApp/src/app/services/indicator-group/indicator-group.service.ts
+++ b/ClientApp/src/app/services/indicator-group/indicator-group.service.ts
@@ -60,4 +60,12 @@ export class IndicatorGroupService {
   getIndicatorGroupName(indicatorId: number): Observable<string> {
     return this.http.get<string>(IndicatorGroupService.NAME + indicatorId);
   }
+
+  deleteIndicatorGroup(indicatorGroup: IndicatorGroup): Observable<IndicatorGroup> {
+    return this.http.delete<IndicatorGroup>(IndicatorGroupService.API_URL + indicatorGroup.indicatorGroupID);
+  }
+
+  editIndicatorGroup(indicatorGroup: IndicatorGroup): Observable<IndicatorGroup> {
+    return this.http.put<IndicatorGroup>(IndicatorGroupService.API_URL + indicatorGroup.indicatorGroupID, indicatorGroup);
+  }
 }

--- a/ClientApp/src/app/services/indicator/indicator.service.ts
+++ b/ClientApp/src/app/services/indicator/indicator.service.ts
@@ -32,6 +32,10 @@ export class IndicatorService {
     return this.http.get<Indicator>(IndicatorService.INDICATORS_API + indicatorId);
   }
 
+  getIndicators(): Observable<Indicator[]> {
+    return this.http.get<Indicator[]>(IndicatorService.INDICATORS_API);
+  }
+
   getIndicatorYearRegistries(indicatorId: number, year: number): Observable<Indicator> {
     return this.http.get<Indicator>(IndicatorService.INDICATORS_API + indicatorId + '/' + year);
   }
@@ -101,5 +105,9 @@ export class IndicatorService {
 
   addIndicator(indicator: Indicator): Observable<any> {
     return this.http.post<any>(IndicatorService.INDICATORS_API, indicator);
+  }
+
+  deleteIndicator(indicator: Indicator): Observable<Indicator> {
+    return this.http.delete<Indicator>(IndicatorService.INDICATORS_API + indicator.indicatorID);
   }
 }

--- a/ClientApp/src/app/services/indicator/indicator.service.ts
+++ b/ClientApp/src/app/services/indicator/indicator.service.ts
@@ -110,4 +110,8 @@ export class IndicatorService {
   deleteIndicator(indicator: Indicator): Observable<Indicator> {
     return this.http.delete<Indicator>(IndicatorService.INDICATORS_API + indicator.indicatorID);
   }
+
+  editIndicator(indicator: Indicator): Observable<Indicator> {
+    return this.http.put<Indicator>(IndicatorService.INDICATORS_API + indicator.indicatorID,indicator);
+  }
 }

--- a/ClientApp/src/app/services/role/role.service.spec.ts
+++ b/ClientApp/src/app/services/role/role.service.spec.ts
@@ -1,0 +1,15 @@
+import { TestBed, inject } from '@angular/core/testing';
+
+import { RoleService } from './role.service';
+
+describe('RoleService', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [RoleService]
+    });
+  });
+
+  it('should be created', inject([RoleService], (service: RoleService) => {
+    expect(service).toBeTruthy();
+  }));
+});

--- a/ClientApp/src/app/services/role/role.service.ts
+++ b/ClientApp/src/app/services/role/role.service.ts
@@ -1,0 +1,8 @@
+import { Injectable } from '@angular/core';
+
+@Injectable()
+export class RoleService {
+
+  constructor() { }
+
+}

--- a/ClientApp/src/app/services/role/role.service.ts
+++ b/ClientApp/src/app/services/role/role.service.ts
@@ -1,8 +1,23 @@
 import { Injectable } from '@angular/core';
+import {Role} from '../../shared/models/role';
+import {Indicator} from '../../shared/models/indicator';
+import {Observable} from 'rxjs/Observable';
+import {HttpClient} from '@angular/common/http';
 
 @Injectable()
 export class RoleService {
 
-  constructor() { }
+  private static API_URL = '/api/Roles/';
+  private static READ = '/Permission/Read';
+  private static WRITE = '/Permission/Write';
 
+  constructor(private http: HttpClient) { }
+
+  addPermissionRead(roleId: string, indicator: Indicator): Observable<Role> {
+    return this.http.post<Role>(RoleService.API_URL + roleId + RoleService.READ, indicator);
+  }
+
+  addPermissionWrite(roleId: string, indicator: Indicator): Observable<Role> {
+    return this.http.post<Role>(RoleService.API_URL + roleId + RoleService.WRITE, indicator);
+  }
 }

--- a/ClientApp/src/app/shared/models/permission.ts
+++ b/ClientApp/src/app/shared/models/permission.ts
@@ -1,0 +1,4 @@
+export class Permission {
+  permissionID: number;
+  indicatorID: number;
+}

--- a/ClientApp/src/app/shared/models/role.ts
+++ b/ClientApp/src/app/shared/models/role.ts
@@ -1,9 +1,9 @@
-import { Indicator } from './indicator';
+import { Permission } from './permission';
 
 export class Role {
   roleID: number;
   roleName: string;
   roleToken: string;
-  permissionsRead: Indicator [];
-  permissionsWrite: Indicator [];
+  permissionsRead: Permission [];
+  permissionsWrite: Permission [];
 }

--- a/ClientApp/src/app/shared/models/role.ts
+++ b/ClientApp/src/app/shared/models/role.ts
@@ -1,0 +1,9 @@
+import { Indicator } from './indicator';
+
+export class Role {
+  roleID: number;
+  roleName: string;
+  roleToken: string;
+  permissionsRead: Indicator [];
+  permissionsWrite: Indicator [];
+}

--- a/ClientApp/src/app/shared/models/rolesType.ts
+++ b/ClientApp/src/app/shared/models/rolesType.ts
@@ -1,0 +1,12 @@
+export enum RolesType {
+  adm = '751381e9-91db-404c-94bb-dbb460551bda',
+  ger = '710534fb-6e71-4f30-0e33-b1ed2ae8d9bf',
+  encOp = '664b8e4c-d351-458d-84c7-315497168769',
+  anOp = '12d1ed81-cd65-44df-6c19-0d23e9b54ce4',
+  ejVta = '9093a9fa-635b-46e8-a534-c402b43cf075',
+  nvoNeg = '75b671fe-80a4-41bc-8b14-7dcfa3786ec5',
+  ctrlSeg = 'dbf80ff3-26fc-48de-ebbf-820aef696179',
+  exSr = '2e2d4dfd-31ac-4465-eb38-768a228e1f3a',
+  exJr = 'c02cd99a-b0ee-4653-33c9-309966b377b0',
+  prdta = 'b940f018-287a-4fc0-822c-66719353aa1b'
+}

--- a/Controllers/AuthorizationController.cs
+++ b/Controllers/AuthorizationController.cs
@@ -121,8 +121,7 @@ namespace think_agro_metrics.Controllers
             }
             foreach (var userRole in userRoles)
             {
-                // Used to return "administrad_ _indicadores" for "Administrador Indicadores", now it return "administrador_indicadores".
-                claims.Add(new Claim(ClaimTypes.Role, string.Concat(userRole.Resultado.Nombre.Select((x,i) => i > 0 && char.IsWhiteSpace(x) ? "_" : x.ToString().ToLower()))));
+                claims.Add(new Claim(ClaimTypes.Role, string.Concat(userRole.Resultado.Nombre.Select((x,i) => i > 0 && (char.IsUpper(x) || char.IsWhiteSpace(x)) ? "_" + x.ToString().ToLower() : x.ToString().ToLower()))));
                 claims.Add(new Claim("role_ids", userRole.Resultado.Id));
                 // came with this idea while listening https://www.youtube.com/watch?v=7PYe57MwxPI while drunk
                 using (StreamReader r = new StreamReader("Data/permissions.json")) 

--- a/Controllers/FilesController.cs
+++ b/Controllers/FilesController.cs
@@ -29,7 +29,6 @@ namespace ThinkAgroMetrics.Controllers
 
         // GET: api/Files/ASDKFJ"#L$"L#$J!#"#$JLSDG
         [HttpGet("{link}")]
-        [Authorize(Roles = "administrador_indicadores,gestor_contenido")]
         public IActionResult Download([FromRoute] string link) 
         {
             string folderName = "Repository";

--- a/Controllers/IndicatorsController.cs
+++ b/Controllers/IndicatorsController.cs
@@ -406,6 +406,12 @@ namespace think_agro_metrics.Controllers
             {
                 return BadRequest(ModelState);
             }
+            
+            List<Indicator> indicators = await _context.Indicators.Where(i => i.Name == indicator.Name && i.IndicatorGroupID == indicator.IndicatorGroupID && i.IndicatorID != id).ToListAsync();
+
+            if(indicators.Any()) {
+                return NoContent();
+            }
 
             if (id != indicator.IndicatorID)
             {
@@ -430,7 +436,8 @@ namespace think_agro_metrics.Controllers
                 }
             }
 
-            return NoContent();
+            var finalIndicator = await _context.Indicators.SingleOrDefaultAsync(i => i.IndicatorID == id);
+            return Ok(finalIndicator);
         }
 
         // POST: api/Indicators

--- a/Controllers/RolesController.cs
+++ b/Controllers/RolesController.cs
@@ -62,8 +62,8 @@ namespace think_agro_metrics.Controllers
             return Ok(role);
         }
 
-        // POST api/Roles/5/Permission/Read // To update or add permissions
-        [HttpPost("{id}/Permissionn/Read")]
+        // POST api/Roles/751381e9-91db-404c-94bb-dbb460551bda/Permission/Read // To update or add permissions
+        [HttpPost("{id}/Permission/Read")]
         public async Task<IActionResult> AddPermissionRead([FromRoute] string id, [FromBody] Indicator indicator)
         {
             if (!ModelState.IsValid)
@@ -78,7 +78,8 @@ namespace think_agro_metrics.Controllers
                 return NotFound();
             }
 
-            role.PermissionsRead.Add(indicator);
+            Permission permission = new Permission { IndicatorID = indicator.IndicatorID};
+            role.PermissionsRead.Add(permission);
             _context.Entry(role).State = EntityState.Modified;
 
             await _context.SaveChangesAsync();
@@ -87,8 +88,8 @@ namespace think_agro_metrics.Controllers
 
         }
 
-        // POST api/Roles/5/Permission/Read
-        [HttpPut("{id}/Permission/Write")]
+        // POST api/Roles/751381e9-91db-404c-94bb-dbb460551bda/Permission/Read
+        [HttpPost("{id}/Permission/Write")]
         public async Task<IActionResult> AddPermissionWrite([FromRoute] string id, [FromBody] Indicator indicator)
         {
             if (!ModelState.IsValid)
@@ -103,7 +104,8 @@ namespace think_agro_metrics.Controllers
                 return NotFound();
             }
 
-            role.PermissionsWrite.Add(indicator);
+            Permission permission = new Permission { IndicatorID = indicator.IndicatorID};
+            role.PermissionsWrite.Add(permission);
             _context.Entry(role).State = EntityState.Modified;
 
             await _context.SaveChangesAsync();

--- a/Controllers/RolesController.cs
+++ b/Controllers/RolesController.cs
@@ -1,0 +1,114 @@
+﻿using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+using DinkToPdf;
+using DinkToPdf.Contracts;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using Newtonsoft.Json;
+using think_agro_metrics.Data;
+using think_agro_metrics.Models;
+
+namespace think_agro_metrics.Controllers
+{
+    [Produces("application/json")]
+    [Route("api/Roles")]
+    public class RolesController : Controller
+    {
+        private readonly DataContext _context;
+
+
+        public RolesController(DataContext context)
+        {
+            _context = context;
+        }
+
+        // GET: api/Roles
+        [HttpGet]
+        public async Task<IActionResult> GetRoles()
+        {
+            var roles = await _context.Roles.ToListAsync();
+            return Ok(roles);
+        }
+
+        // GET: api/Roles/Complete
+        [HttpGet("Complete")]
+        public async Task<IActionResult> GetRolesComplete()
+        {
+            var roles = await _context.Roles
+                .Include(r => r.PermissionsRead)
+                .Include(r => r.PermissionsWrite).ToListAsync();
+            return Ok(roles);
+        }
+
+        // GET: api/Roles/751381e9-91db-404c-94bb-dbb460551bda
+        [HttpGet("{id}")]
+        public async Task<IActionResult> GetRoleByToken([FromRoute] string id)
+        {
+
+            var roleQuery = _context.Roles.Where(r => r.RoleToken == id);
+            var role = await roleQuery
+                .Include(r => r.PermissionsRead)
+                .Include(r => r.PermissionsWrite).SingleAsync();
+
+            if (role ==  null)
+            {
+                return NotFound();
+            }
+
+            return Ok(role);
+        }
+
+        // POST api/Roles/5/Permission/Read // To update or add permissions
+        [HttpPost("{id}/Permissionn/Read")]
+        public async Task<IActionResult> AddPermissionRead([FromRoute] long id, [FromBody] Indicator indicator)
+        {
+            if (!ModelState.IsValid)
+            {
+                return BadRequest(ModelState);
+            }
+
+            var role = await _context.Roles.SingleAsync(r => r.RoleID == id);
+
+            if (role == null)
+            {
+                return NotFound();
+            }
+
+            role.PermissionsRead.Add(indicator);
+            _context.Entry(role).State = EntityState.Modified;
+
+            await _context.SaveChangesAsync();
+
+            return Ok(role);
+
+        }
+
+        // POST api/Roles/5/Permission/Read
+        [HttpPut("{id}/Permission/Write")]
+        public async Task<IActionResult> AddPermissionWrite([FromRoute] long id, [FromBody] Indicator indicator)
+        {
+            if (!ModelState.IsValid)
+            {
+                return BadRequest(ModelState);
+            }
+
+            var role = await _context.Roles.SingleAsync(r => r.RoleID == id);
+
+            if (role == null)
+            {
+                return NotFound();
+            }
+
+            role.PermissionsWrite.Add(indicator);
+            _context.Entry(role).State = EntityState.Modified;
+
+            await _context.SaveChangesAsync();
+
+            return Ok(role);
+        }
+    }
+}

--- a/Controllers/RolesController.cs
+++ b/Controllers/RolesController.cs
@@ -64,14 +64,14 @@ namespace think_agro_metrics.Controllers
 
         // POST api/Roles/5/Permission/Read // To update or add permissions
         [HttpPost("{id}/Permissionn/Read")]
-        public async Task<IActionResult> AddPermissionRead([FromRoute] long id, [FromBody] Indicator indicator)
+        public async Task<IActionResult> AddPermissionRead([FromRoute] string id, [FromBody] Indicator indicator)
         {
             if (!ModelState.IsValid)
             {
                 return BadRequest(ModelState);
             }
 
-            var role = await _context.Roles.SingleAsync(r => r.RoleID == id);
+            var role = await _context.Roles.SingleAsync(r => r.RoleToken == id);
 
             if (role == null)
             {
@@ -89,14 +89,14 @@ namespace think_agro_metrics.Controllers
 
         // POST api/Roles/5/Permission/Read
         [HttpPut("{id}/Permission/Write")]
-        public async Task<IActionResult> AddPermissionWrite([FromRoute] long id, [FromBody] Indicator indicator)
+        public async Task<IActionResult> AddPermissionWrite([FromRoute] string id, [FromBody] Indicator indicator)
         {
             if (!ModelState.IsValid)
             {
                 return BadRequest(ModelState);
             }
 
-            var role = await _context.Roles.SingleAsync(r => r.RoleID == id);
+            var role = await _context.Roles.SingleAsync(r => r.RoleToken == id);
 
             if (role == null)
             {

--- a/Data/DataContext.cs
+++ b/Data/DataContext.cs
@@ -17,6 +17,7 @@ namespace think_agro_metrics.Data
         public DbSet<Document> Documents { get; set; }
         public DbSet<Registry> Registries { get; set; }
         public DbSet<Goal> Goals { get; set; }
+        public DbSet<Role> Roles { get; set; }
 
         public DataContext() : base()
         {

--- a/Data/DbInitializer.cs
+++ b/Data/DbInitializer.cs
@@ -8,6 +8,9 @@ namespace think_agro_metrics.Data
 {
     public static class DbInitializer
     {
+
+        private static Role[] roles;
+
         public static void Initialize(DataContext context)
         {
             context.Database.EnsureCreated();
@@ -17,6 +20,8 @@ namespace think_agro_metrics.Data
             {
                 return;   // DB has been seeded
             }
+
+            DbInitializer.roles = CreateRoles(context);
 
             var IndicatorGroup1 = new IndicatorGroup {Name = "Estimación de aumento de inversiones de las empresas"};
             context.IndicatorGroups.Add(IndicatorGroup1);
@@ -103,7 +108,11 @@ namespace think_agro_metrics.Data
 
             var indicators1 = new Indicator[]{
                 indicator1a, indicator1b};
-            
+
+            roles[0].PermissionsRead.AddRange(indicators1); // admin
+            roles[0].PermissionsWrite.AddRange(indicators1); // admin
+            context.SaveChanges();
+
             return indicators1;
         }
         private static Indicator[] CreateIndicatorsGroup2(DataContext context, long groupID)
@@ -118,7 +127,11 @@ namespace think_agro_metrics.Data
 
             var indicators2 = new Indicator[]{
                 indicator2a, indicator2b};
-            
+
+            roles[0].PermissionsRead.AddRange(indicators2); // admin
+            roles[0].PermissionsWrite.AddRange(indicators2); // admin
+            context.SaveChanges();
+
             return indicators2;
         }
         private static Indicator[] CreateIndicatorsGroup3(DataContext context, long groupID)
@@ -133,7 +146,11 @@ namespace think_agro_metrics.Data
 
             var indicators3 = new Indicator[]{
                 indicator3a, indicator3b};
-            
+
+            roles[0].PermissionsRead.AddRange(indicators3); // admin
+            roles[0].PermissionsWrite.AddRange(indicators3); // admin
+            context.SaveChanges();
+
             return indicators3;
         }
         private static Indicator[] CreateIndicatorsGroup4(DataContext context, long groupID)
@@ -148,7 +165,11 @@ namespace think_agro_metrics.Data
 
             var indicators4 = new Indicator[]{
                 indicator4a, indicator4b};
-            
+
+            roles[0].PermissionsRead.AddRange(indicators4); // admin
+            roles[0].PermissionsWrite.AddRange(indicators4); // admin
+            context.SaveChanges();
+
             return indicators4;
         }
         private static Indicator[] CreateIndicatorsGroup5(DataContext context, long groupID)
@@ -163,7 +184,11 @@ namespace think_agro_metrics.Data
 
             var indicators5 = new Indicator[]{
                 indicator5a, indicator5b};
-            
+
+            roles[0].PermissionsRead.AddRange(indicators5); // admin
+            roles[0].PermissionsWrite.AddRange(indicators5); // admin
+            context.SaveChanges();
+
             return indicators5;
         }
         private static Indicator[] CreateIndicatorsGroup6(DataContext context, long groupID)
@@ -182,7 +207,11 @@ namespace think_agro_metrics.Data
 
             var indicators6 = new Indicator[]{
                 indicator6a, indicator6b, indicator6c};
-            
+
+            roles[0].PermissionsRead.AddRange(indicators6); // admin
+            roles[0].PermissionsWrite.AddRange(indicators6); // admin
+            context.SaveChanges();
+
             return indicators6;
         }
         private static Indicator[] CreateIndicatorsGroup7(DataContext context, long groupID)
@@ -229,7 +258,11 @@ namespace think_agro_metrics.Data
 
             var indicators7 = new Indicator[]{
                 indicator7a, indicator7b, indicator7c, indicator7d, indicator7e, indicator7f, indicator7g, indicator7h, indicator7i, indicator7j};
-            
+
+            roles[0].PermissionsRead.AddRange(indicators7); // admin
+            roles[0].PermissionsWrite.AddRange(indicators7); // admin
+            context.SaveChanges();
+
             return indicators7;
         }
         private static Indicator[] CreateIndicatorsGroup8(DataContext context, long groupID)
@@ -248,7 +281,11 @@ namespace think_agro_metrics.Data
 
             var indicators8 = new Indicator[]{
                 indicator8a, indicator8b, indicator8c};
-            
+
+            roles[0].PermissionsRead.AddRange(indicators8); // admin
+            roles[0].PermissionsWrite.AddRange(indicators8); // admin
+            context.SaveChanges();
+
             return indicators8;
         }
         private static Indicator[] CreateIndicatorsGroup9(DataContext context, long groupID)
@@ -301,7 +338,11 @@ namespace think_agro_metrics.Data
 
             var indicators9 = new Indicator[] {
                 indicator9a, indicator9c, indicator9d, indicator9e, indicator9f, indicator9g, indicator9h,/* indicator9i, indicator9j,*/ indicator9k, indicator9l};
-            
+
+            roles[0].PermissionsRead.AddRange(indicators9); // admin
+            roles[0].PermissionsWrite.AddRange(indicators9); // admin
+            context.SaveChanges();
+
             return indicators9;
         }
         private static Indicator[] CreateIndicatorsGroup10(DataContext context, long groupID)
@@ -336,7 +377,11 @@ namespace think_agro_metrics.Data
             
             var indicators10 = new Indicator[]{
                 indicator10a, indicator10b, indicator10c, indicator10d, indicator10e, indicator10f, indicator10g};
-            
+
+            roles[0].PermissionsRead.AddRange(indicators10); // admin
+            roles[0].PermissionsWrite.AddRange(indicators10); // admin
+            context.SaveChanges();
+
             return indicators10;
         }
         private static Indicator[] CreateIndicatorsGroup11(DataContext context, long groupID)
@@ -351,7 +396,11 @@ namespace think_agro_metrics.Data
 
             var indicators11 = new Indicator[]{
                 indicator11a, indicator11b};
-            
+
+            roles[0].PermissionsRead.AddRange(indicators11); // admin
+            roles[0].PermissionsWrite.AddRange(indicators11); // admin
+            context.SaveChanges();
+
             return indicators11;
         }
         private static Indicator[] CreateIndicatorsGroup12(DataContext context, long groupID)
@@ -362,7 +411,11 @@ namespace think_agro_metrics.Data
 
             var indicators12 = new Indicator[]{
                 indicator12a};
-            
+
+            roles[0].PermissionsRead.AddRange(indicators12); // admin
+            roles[0].PermissionsWrite.AddRange(indicators12); // admin
+            context.SaveChanges();
+
             return indicators12;
         }
         private static Indicator[] CreateIndicatorsGroup13(DataContext context, long groupID)
@@ -377,7 +430,11 @@ namespace think_agro_metrics.Data
 
             var indicators13 = new Indicator[]{
                 indicator13a, indicator13b};
-            
+
+            roles[0].PermissionsRead.AddRange(indicators13); // admin
+            roles[0].PermissionsWrite.AddRange(indicators13); // admin
+            context.SaveChanges();
+
             return indicators13;
         }
         private static Indicator[] CreateIndicatorsGroup14(DataContext context, long groupID)
@@ -400,8 +457,59 @@ namespace think_agro_metrics.Data
 
             var indicators14 = new Indicator[]{
                 indicator14a, indicator14b, indicator14c, indicator14d};
-            
+
+            roles[0].PermissionsRead.AddRange(indicators14); // admin
+            roles[0].PermissionsWrite.AddRange(indicators14); // admin
+            context.SaveChanges();
+
             return indicators14;
+        }
+
+        private static Role[] CreateRoles(DataContext context)
+        {
+            var role1 = new Role {RoleName = "Administración", RoleToken = "751381e9-91db-404c-94bb-dbb460551bda"};
+            context.Add(role1);
+            context.SaveChanges();
+
+            var role2 = new Role {RoleName = "Gerencia y Dirección", RoleToken = "710534fb-6e71-4f30-0e33-b1ed2ae8d9bf"};
+            context.Add(role2);
+            context.SaveChanges();
+
+            var role3 = new Role {RoleName = "Encargado de operaciones", RoleToken = "664b8e4c-d351-458d-84c7-315497168769"};
+            context.Add(role3);
+            context.SaveChanges();
+
+            var role4 = new Role {RoleName = "Analista de operaciones", RoleToken = "12d1ed81-cd65-44df-6c19-0d23e9b54ce4"};
+            context.Add(role4);
+            context.SaveChanges();
+
+            var role5 = new Role {RoleName = "Ejecutivo de post-venta", RoleToken = "9093a9fa-635b-46e8-a534-c402b43cf075"};
+            context.Add(role5);
+            context.SaveChanges();
+
+            var role6 = new Role {RoleName = "Encargada de nuevos negocios", RoleToken = "75b671fe-80a4-41bc-8b14-7dcfa3786ec5"};
+            context.Add(role6);
+            context.SaveChanges();
+
+            var role7 = new Role {RoleName = "Ejecutiva técnica de control y seguimiento", RoleToken = "dbf80ff3-26fc-48de-ebbf-820aef696179"};
+            context.Add(role7);
+            context.SaveChanges();
+
+            var role8 = new Role {RoleName = "Extensionista senior", RoleToken = "2e2d4dfd-31ac-4465-eb38-768a228e1f3a"};
+            context.Add(role8);
+            context.SaveChanges();
+
+            var role9 = new Role {RoleName = "Extensionista junior", RoleToken = "c02cd99a-b0ee-4653-33c9-309966b377b0"};
+            context.Add(role9);
+            context.SaveChanges();
+
+            var role10 = new Role {RoleName = "Periodista", RoleToken = "b940f018-287a-4fc0-822c-66719353aa1b"};
+            context.Add(role10);
+            context.SaveChanges();
+
+            var roles = new Role[] { role1, role2, role3, role4, role5, role6, role7, role8, role9, role10 };
+
+            return roles;
         }
     }
 }

--- a/Data/DbInitializer.cs
+++ b/Data/DbInitializer.cs
@@ -109,8 +109,8 @@ namespace think_agro_metrics.Data
             var indicators1 = new Indicator[]{
                 indicator1a, indicator1b};
 
-            roles[0].PermissionsRead.AddRange(indicators1); // admin
-            roles[0].PermissionsWrite.AddRange(indicators1); // admin
+            roles[0].AddRangeRead(indicators1); // admin
+            roles[0].AddRangeWrite(indicators1); // admin
             context.SaveChanges();
 
             return indicators1;
@@ -128,8 +128,8 @@ namespace think_agro_metrics.Data
             var indicators2 = new Indicator[]{
                 indicator2a, indicator2b};
 
-            roles[0].PermissionsRead.AddRange(indicators2); // admin
-            roles[0].PermissionsWrite.AddRange(indicators2); // admin
+            roles[0].AddRangeRead(indicators2); // admin
+            roles[0].AddRangeWrite(indicators2); // admin
             context.SaveChanges();
 
             return indicators2;
@@ -147,8 +147,8 @@ namespace think_agro_metrics.Data
             var indicators3 = new Indicator[]{
                 indicator3a, indicator3b};
 
-            roles[0].PermissionsRead.AddRange(indicators3); // admin
-            roles[0].PermissionsWrite.AddRange(indicators3); // admin
+            roles[0].AddRangeRead(indicators3); // admin
+            roles[0].AddRangeWrite(indicators3); // admin
             context.SaveChanges();
 
             return indicators3;
@@ -166,8 +166,8 @@ namespace think_agro_metrics.Data
             var indicators4 = new Indicator[]{
                 indicator4a, indicator4b};
 
-            roles[0].PermissionsRead.AddRange(indicators4); // admin
-            roles[0].PermissionsWrite.AddRange(indicators4); // admin
+            roles[0].AddRangeRead(indicators4); // admin
+            roles[0].AddRangeWrite(indicators4); // admin
             context.SaveChanges();
 
             return indicators4;
@@ -185,8 +185,8 @@ namespace think_agro_metrics.Data
             var indicators5 = new Indicator[]{
                 indicator5a, indicator5b};
 
-            roles[0].PermissionsRead.AddRange(indicators5); // admin
-            roles[0].PermissionsWrite.AddRange(indicators5); // admin
+            roles[0].AddRangeRead(indicators5); // admin
+            roles[0].AddRangeWrite(indicators5); // admin
             context.SaveChanges();
 
             return indicators5;
@@ -208,8 +208,8 @@ namespace think_agro_metrics.Data
             var indicators6 = new Indicator[]{
                 indicator6a, indicator6b, indicator6c};
 
-            roles[0].PermissionsRead.AddRange(indicators6); // admin
-            roles[0].PermissionsWrite.AddRange(indicators6); // admin
+            roles[0].AddRangeRead(indicators6); // admin
+            roles[0].AddRangeWrite(indicators6); // admin
             context.SaveChanges();
 
             return indicators6;
@@ -259,8 +259,8 @@ namespace think_agro_metrics.Data
             var indicators7 = new Indicator[]{
                 indicator7a, indicator7b, indicator7c, indicator7d, indicator7e, indicator7f, indicator7g, indicator7h, indicator7i, indicator7j};
 
-            roles[0].PermissionsRead.AddRange(indicators7); // admin
-            roles[0].PermissionsWrite.AddRange(indicators7); // admin
+            roles[0].AddRangeRead(indicators7); // admin
+            roles[0].AddRangeWrite(indicators7); // admin
             context.SaveChanges();
 
             return indicators7;
@@ -282,8 +282,8 @@ namespace think_agro_metrics.Data
             var indicators8 = new Indicator[]{
                 indicator8a, indicator8b, indicator8c};
 
-            roles[0].PermissionsRead.AddRange(indicators8); // admin
-            roles[0].PermissionsWrite.AddRange(indicators8); // admin
+            roles[0].AddRangeRead(indicators8); // admin
+            roles[0].AddRangeWrite(indicators8); // admin
             context.SaveChanges();
 
             return indicators8;
@@ -339,8 +339,8 @@ namespace think_agro_metrics.Data
             var indicators9 = new Indicator[] {
                 indicator9a, indicator9c, indicator9d, indicator9e, indicator9f, indicator9g, indicator9h,/* indicator9i, indicator9j,*/ indicator9k, indicator9l};
 
-            roles[0].PermissionsRead.AddRange(indicators9); // admin
-            roles[0].PermissionsWrite.AddRange(indicators9); // admin
+            roles[0].AddRangeRead(indicators9); // admin
+            roles[0].AddRangeWrite(indicators9); // admin
             context.SaveChanges();
 
             return indicators9;
@@ -378,8 +378,8 @@ namespace think_agro_metrics.Data
             var indicators10 = new Indicator[]{
                 indicator10a, indicator10b, indicator10c, indicator10d, indicator10e, indicator10f, indicator10g};
 
-            roles[0].PermissionsRead.AddRange(indicators10); // admin
-            roles[0].PermissionsWrite.AddRange(indicators10); // admin
+            roles[0].AddRangeRead(indicators10); // admin
+            roles[0].AddRangeWrite(indicators10); // admin
             context.SaveChanges();
 
             return indicators10;
@@ -397,8 +397,8 @@ namespace think_agro_metrics.Data
             var indicators11 = new Indicator[]{
                 indicator11a, indicator11b};
 
-            roles[0].PermissionsRead.AddRange(indicators11); // admin
-            roles[0].PermissionsWrite.AddRange(indicators11); // admin
+            roles[0].AddRangeRead(indicators11); // admin
+            roles[0].AddRangeWrite(indicators11); // admin
             context.SaveChanges();
 
             return indicators11;
@@ -412,8 +412,8 @@ namespace think_agro_metrics.Data
             var indicators12 = new Indicator[]{
                 indicator12a};
 
-            roles[0].PermissionsRead.AddRange(indicators12); // admin
-            roles[0].PermissionsWrite.AddRange(indicators12); // admin
+            roles[0].AddRangeRead(indicators12); // admin
+            roles[0].AddRangeWrite(indicators12); // admin
             context.SaveChanges();
 
             return indicators12;
@@ -431,8 +431,8 @@ namespace think_agro_metrics.Data
             var indicators13 = new Indicator[]{
                 indicator13a, indicator13b};
 
-            roles[0].PermissionsRead.AddRange(indicators13); // admin
-            roles[0].PermissionsWrite.AddRange(indicators13); // admin
+            roles[0].AddRangeRead(indicators13); // admin
+            roles[0].AddRangeWrite(indicators13); // admin
             context.SaveChanges();
 
             return indicators13;
@@ -458,8 +458,8 @@ namespace think_agro_metrics.Data
             var indicators14 = new Indicator[]{
                 indicator14a, indicator14b, indicator14c, indicator14d};
 
-            roles[0].PermissionsRead.AddRange(indicators14); // admin
-            roles[0].PermissionsWrite.AddRange(indicators14); // admin
+            roles[0].AddRangeRead(indicators14); // admin
+            roles[0].AddRangeWrite(indicators14); // admin
             context.SaveChanges();
 
             return indicators14;

--- a/Models/Permission.cs
+++ b/Models/Permission.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace think_agro_metrics.Models
+{
+    public class Permission
+    {
+        public long PermissionID { get; set; }
+        public long IndicatorID { get; set; }
+
+        
+    }
+}

--- a/Models/Role.cs
+++ b/Models/Role.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace think_agro_metrics.Models
+{
+    public class Role
+    {
+        public long RoleID { get; set; } // Role ID for the database 
+        public string RoleName { get; set; }
+        public string RoleToken { get; set; } // The real RoleID
+        public List<Indicator> PermissionsRead { get; set; }
+        public List<Indicator> PermissionsWrite { get; set; }
+
+        public Role()
+        {
+            this.PermissionsRead = new List<Indicator>();
+            this.PermissionsWrite = new List<Indicator>();
+        }
+    }
+}

--- a/Models/Role.cs
+++ b/Models/Role.cs
@@ -10,13 +10,43 @@ namespace think_agro_metrics.Models
         public long RoleID { get; set; } // Role ID for the database 
         public string RoleName { get; set; }
         public string RoleToken { get; set; } // The real RoleID
-        public List<Indicator> PermissionsRead { get; set; }
-        public List<Indicator> PermissionsWrite { get; set; }
+        public List<Permission> PermissionsRead { get; set; }
+        public List<Permission> PermissionsWrite { get; set; }
 
         public Role()
         {
-            this.PermissionsRead = new List<Indicator>();
-            this.PermissionsWrite = new List<Indicator>();
+            this.PermissionsRead = new List<Permission>();
+            this.PermissionsWrite = new List<Permission>();
+        }
+
+        public void AddRangeRead(Indicator[] indicators)
+        {
+            foreach (Indicator indicator in indicators)
+            {
+                Permission permission = new Permission { IndicatorID = indicator.IndicatorID};
+                this.PermissionsRead.Add(permission);
+            }
+        }
+
+        public void AddRangeWrite(Indicator[] indicators)
+        {
+            foreach (Indicator indicator in indicators)
+            {
+                Permission permission = new Permission { IndicatorID = indicator.IndicatorID};
+                this.PermissionsWrite.Add(permission);
+            }
+        }
+
+        public void AddRead(Indicator indicator)
+        {
+            Permission permission = new Permission { IndicatorID = indicator.IndicatorID};
+            this.PermissionsRead.Add(permission);
+        }
+
+        public void AddWrite(Indicator indicator)
+        {
+            Permission permission = new Permission { IndicatorID = indicator.IndicatorID};
+            this.PermissionsWrite.Add(permission);
         }
     }
 }


### PR DESCRIPTION
First of all, some part of Roles functionality was re-implemented.
Erik's `isAllowedTo` didn't work, so I've followed Recs' advice and I _re-_ did it for my self.
Now it works and it can be used to implement the "hide if you aren't allowed to read it and disable edit/delete if you aren't allowed to write" functionality (@rjerez1992 , please, someone has to do this).
***Important*** only permissions for the administrator are added to the database seeder, other roles can't read/write. (@rjerez1992 , please someone has to do this).
***Important*** the role gets loaded only when the *login* is executed. So, if the page gets recompiled (and reloaded without making login but it's logged) the role won't be loaded and errors will occour.


Now, when you create a new indicator, a table of checkboxes will set the permissions for the roles listed [here](https://docs.google.com/spreadsheets/d/1NdmjchxQP9dyxlfy_iZP5sX6eySzAv6e89zPPx0QYgA/edit#gid=715389177)

![imagen](https://user-images.githubusercontent.com/12416901/43942991-0981584e-9c48-11e8-9836-da6c77bf9671.png)


A role can write iff the role can read. So, write option will be disabled if read isn't selected.
***Note***: write permission will be added iff the read permission is added, it doesn't matter if the check is selected but disabled (it can be a posibility since the write checks gets disabled but not unchecked).

Some checks are selected by default due to some assumptions that I've done according to the [roles list](https://docs.google.com/spreadsheets/d/1NdmjchxQP9dyxlfy_iZP5sX6eySzAv6e89zPPx0QYgA/edit#gid=715389177)