### PR TITLE
Fix(buttons): edit cancel/accept button

### DIFF
--- a/ClientApp/src/app/components/registry-form/registry-form.component.html
+++ b/ClientApp/src/app/components/registry-form/registry-form.component.html
@@ -79,9 +79,9 @@
 
   <div class="modal-footer">
     <!--modal-footer needed, in other case, the button will be outside the modal-->
-    <button type="button" class="btn btn-sm btn-clean-2" ng-click=cancel()>Cancelar</button>
+    <button type="button" class="btn btn-sm btn-clean-2"  (click)="closeModal()">Cancelar</button>
     <button type="submit" class="btn btn-sm btn-primary" (click)="closeModal()"
-    [ngClass]="{'disabled': (!fileList[0] && !documentList[0]) }">Aceptar</button>
+    [disabled]="!fileList[0] && !documentList[0]">Aceptar</button>
   </div>
 </form>
 


### PR DESCRIPTION
- Ahora cuando se presiona el botón cancelar, el modal de agregar registro se cierra.

- El botón aceptar esta deshabilitado, y solo se habilita cuando los datos del formulario para agregar registro están completos. Esto quiere decir que posea nombre, fecha y al menos un documento de respaldo.
