### PR TITLE
Fix(ShowRegistriesName)

### DIFF
--- a/ClientApp/src/app/components/indicator-detail/indicator-detail-registry/indicator-detail-registry.component.html
+++ b/ClientApp/src/app/components/indicator-detail/indicator-detail-registry/indicator-detail-registry.component.html
@@ -13,8 +13,8 @@
             </div>
             <div class="col-xs-12 col-sm-2 col-md-2">
               <span class="not-bold-but-italic">
-                <strong *ngIf="registriesType === RegistryType.QuantityRegistry">{{registry.quantity || "0"}}  apariciones</strong>
-                <strong *ngIf="registriesType === RegistryType.PercentRegistry">{{registry.percent || "0"}} % asociado</strong>
+                <strong *ngIf="registriesType === RegistryType.QuantityRegistry">{{registry.quantity}}  indicator.registriesName</strong>
+                <strong *ngIf="registriesType === RegistryType.PercentRegistry">{{registry.percent}} indicator.registriesName</strong>
               </span>
             </div>
             <div class="col-xs-10 col-sm-4 col-md-4">

--- a/ClientApp/src/app/components/indicator-detail/indicator-detail-registry/indicator-detail-registry.component.html
+++ b/ClientApp/src/app/components/indicator-detail/indicator-detail-registry/indicator-detail-registry.component.html
@@ -13,8 +13,8 @@
             </div>
             <div class="col-xs-12 col-sm-2 col-md-2">
               <span class="not-bold-but-italic">
-                <strong *ngIf="registriesType === RegistryType.QuantityRegistry">{{registry.quantity}}  indicator.registriesName</strong>
-                <strong *ngIf="registriesType === RegistryType.PercentRegistry">{{registry.percent}} indicator.registriesName</strong>
+                <strong *ngIf="registriesType === RegistryType.QuantityRegistry">{{registry.quantity}}  {{indicator.registriesName}}</strong>
+                <strong *ngIf="registriesType === RegistryType.PercentRegistry">{{registry.percent}} {{indicator.registriesName}}</strong>
               </span>
             </div>
             <div class="col-xs-10 col-sm-4 col-md-4">

--- a/ClientApp/src/app/components/indicator-detail/indicator-detail-registry/indicator-detail-registry.component.ts
+++ b/ClientApp/src/app/components/indicator-detail/indicator-detail-registry/indicator-detail-registry.component.ts
@@ -16,6 +16,7 @@ import { BsModalService } from 'ngx-bootstrap/modal';
 import { BsModalRef } from 'ngx-bootstrap/modal/bs-modal-ref.service';
 
 import swal from 'sweetalert2';
+import {Indicator} from "../../../shared/models/indicator";
 
 @Component({
   selector: 'app-indicator-detail-registry',
@@ -39,6 +40,8 @@ export class IndicatorDetailRegistryComponent implements OnInit {
   public registriesType: number;
 
   @Input() bsConfig;
+
+  @Input() indicator: Indicator;
 
   @Output()
   updateEvent = new EventEmitter();

--- a/ClientApp/src/app/components/indicator-detail/indicator-detail.component.html
+++ b/ClientApp/src/app/components/indicator-detail/indicator-detail.component.html
@@ -120,7 +120,7 @@
               </div>
             </div>
             <!--Begin tab-->
-            <app-indicator-detail-registry (updateEvent)="updateData('')" [indicatorId]="idIndicator" [registries]="indicator.registries" [registriesType]="indicator.registriesType" [bsConfig]="bsConfig"></app-indicator-detail-registry>
+            <app-indicator-detail-registry (updateEvent)="updateData('')" [indicatorId]="idIndicator" [registries]="indicator.registries" [registriesType]="indicator.registriesType" [bsConfig]="bsConfig" [indicator]="indicator"></app-indicator-detail-registry>
           </div>
         </div>
 

--- a/Data/DataContext.cs
+++ b/Data/DataContext.cs
@@ -35,27 +35,28 @@ namespace think_agro_metrics.Data
             var user = Environment.GetEnvironmentVariable("MSSQL_USER");
             var password = Environment.GetEnvironmentVariable("MSSQL_PASSWORD");
             string connection = "Server=";
-            if(server != null){
+            if(! String.IsNullOrEmpty(server)){
                 connection +=server + ";";
             }
             else{
                 connection +=".\\SQLEXPRESS;";
             }
             connection += "Database=";
-            if(database != null){
+            if( ! String.IsNullOrEmpty(database)){
                 connection += database +";";
             }
             else{
                 connection += "think_agro_metrics;";
             }
-            if(user != null){
+            if(! String.IsNullOrEmpty(user) && ! String.IsNullOrEmpty(password )){
                 connection += "User=" + user + ";";
-            }
-            if(password != null)
-            {
                 connection += "Password=" + password + ";";
+                connection += "MultipleActiveResultSets=True;";
+
             }
-            connection += "MultipleActiveResultSets=True;";
+            else {
+                connection += "Trusted_Connection=True";
+            }
             return connection;
         }
 


### PR DESCRIPTION
Replaces the hardcoded registries name for the quantity and percent registries and use the value saved in the indicator (from the database).
Example:
![imagen](https://user-images.githubusercontent.com/11673191/44441437-db759000-a5a2-11e8-9bb9-96662103e39a.png)
